### PR TITLE
feat(video): support batch upload of multiple videos

### DIFF
--- a/public/video-preview.html
+++ b/public/video-preview.html
@@ -287,6 +287,32 @@
       gap: 20px;
     }
 
+    /* Batch queue (multiple videos) */
+    .batch-queue {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 10px;
+    }
+    .batch-item {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      font-size: 13px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      background: rgba(148, 163, 184, 0.12);
+    }
+    .batch-item .batch-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .batch-item .batch-state { flex: none; opacity: 0.85; }
+    .batch-item[data-status="processing"] .batch-state { color: #2563eb; }
+    .batch-item[data-status="done"] .batch-state { color: #16a34a; }
+    .batch-item[data-status="error"] .batch-state { color: #dc2626; }
+
     /* Dropzone */
     .dropzone {
       border: 2px dashed #cbd5e1;
@@ -505,8 +531,9 @@
         <div id="dropzone" class="dropzone" data-dragging="false" role="button" tabindex="0">
           <strong>选择文件</strong>
           <span class="muted">视频会在本页处理，图片会回到单图对比页。10 秒 1080p MP4 样例最适合当前 MVP。</span>
-          <input id="fileInput" type="file" accept="image/jpeg,image/png,image/webp,video/mp4,video/webm,video/quicktime,video/*" hidden>
+          <input id="fileInput" type="file" accept="image/jpeg,image/png,image/webp,video/mp4,video/webm,video/quicktime,video/*" multiple hidden>
         </div>
+        <div id="batchQueue" class="batch-queue" aria-label="批量队列" hidden></div>
 
         <div class="panel">
           <div class="panel-head">自动处理</div>

--- a/src/video-app.js
+++ b/src/video-app.js
@@ -20,6 +20,12 @@ import {
 import { resolveAllenkFdncnnRuntimeProfile } from './video/videoDenoiseRuntimePolicy.js';
 import { applyVideoBitrateDebugOverride } from './video/videoDebugControlOverrides.js';
 import {
+    createBatchQueue,
+    enqueueBatchFiles,
+    processBatchQueue,
+    startBatchSelection
+} from './video/videoBatchQueue.js';
+import {
     consumeDebugFileHandoff,
     getDebugFileKind,
     pickDebugUploadFile,
@@ -676,7 +682,7 @@ async function runExport() {
 // --- Batch processing (multiple videos, one at a time) ---
 // Video decode/encode is CPU/GPU-bound, so sequential processing through the
 // existing single-file pipeline is the correct design, not a compromise.
-const batch = { queue: [], processing: false };
+const batch = createBatchQueue();
 
 function batchStatusLabel(status) {
     switch (status) {
@@ -692,13 +698,13 @@ function batchStatusLabel(status) {
 function renderBatchQueue() {
     const box = els.batchQueue;
     if (!box) return;
-    if (batch.queue.length === 0) {
+    if (batch.items.length === 0) {
         box.hidden = true;
         box.replaceChildren();
         return;
     }
     box.hidden = false;
-    box.replaceChildren(...batch.queue.map((item, index) => {
+    box.replaceChildren(...batch.items.map((item, index) => {
         const row = document.createElement('div');
         row.className = 'batch-item';
         row.dataset.status = item.status;
@@ -722,67 +728,63 @@ function triggerDownload(href, filename) {
     anchor.remove();
 }
 
-async function processBatch() {
-    if (batch.processing) return;
-    batch.processing = true;
-    try {
-        for (const item of batch.queue) {
-            if (item.status !== 'pending') continue;
-            item.status = 'processing';
-            renderBatchQueue();
-            try {
-                await setFile(item.file);
-                if (getDebugFileKind(item.file) !== 'video' || !state.file) {
-                    item.status = 'skipped';
-                    renderBatchQueue();
-                    continue;
-                }
-                await runExport();
-                const href = els.downloadBtn.getAttribute('href');
-                if (state.processedUrl && href) {
-                    triggerDownload(href, els.downloadBtn.getAttribute('download') || `${item.file.name}.mp4`);
-                    item.status = 'done';
-                } else {
-                    item.status = 'error';
-                }
-            } catch (error) {
-                console.error(error);
-                item.status = 'error';
-            }
-            renderBatchQueue();
-        }
-        const done = batch.queue.filter((it) => it.status === 'done').length;
-        setStatus(`批量处理完成：成功 ${done}/${batch.queue.length}，结果已自动下载。`, done ? 'success' : 'warn');
-    } finally {
-        batch.processing = false;
-    }
+async function exportQueuedVideo(file) {
+    await setFile(file);
+    if (getDebugFileKind(file) !== 'video' || !state.file) return { skipped: true };
+
+    await runExport();
+    const href = els.downloadBtn.getAttribute('href');
+    if (!state.processedUrl || !href) return { ok: false };
+
+    return {
+        ok: true,
+        href,
+        filename: els.downloadBtn.getAttribute('download') || `${file.name}.mp4`
+    };
+}
+
+async function runBatch() {
+    const summary = await processBatchQueue(batch, {
+        processFile: exportQueuedVideo,
+        downloadResult: ({ href, filename }) => triggerDownload(href, filename),
+        onChange: renderBatchQueue,
+        onError: (error) => console.error(error)
+    });
+    if (!summary) return;
+
+    setStatus(
+        `批量处理完成：成功 ${summary.done}/${summary.total}，结果已自动下载。`,
+        summary.done ? 'success' : 'warn'
+    );
 }
 
 function handleIncomingFiles(fileList) {
     const list = Array.from(fileList || []).filter(Boolean);
     const videoFiles = list.filter((file) => getDebugFileKind(file) === 'video');
 
+    // Drop a finished queue before anything else, so completed rows never leak
+    // into the next selection — batch or single-file.
+    startBatchSelection(batch);
+
     if (videoFiles.length > 1) {
-        for (const file of videoFiles) {
-            batch.queue.push({ file, status: 'pending' });
-        }
+        enqueueBatchFiles(batch, videoFiles);
         renderBatchQueue();
-        processBatch();
+        runBatch();
         return;
     }
 
     // Single video (or an image handoff): keep the original single-file behavior
-    // so preset tuning and manual export still work.
+    // so preset tuning and manual export still work. Rendering the now-empty
+    // queue hides any stale batch UI.
+    renderBatchQueue();
     const file = pickDebugUploadFile(fileList);
     if (file) setFile(file);
 }
 
 function reset() {
     state.jobId++;
-    if (!batch.processing) {
-        batch.queue = [];
-        renderBatchQueue();
-    }
+    startBatchSelection(batch);
+    renderBatchQueue();
     cleanupUrls();
     state.file = null;
     state.metadata = null;

--- a/src/video-app.js
+++ b/src/video-app.js
@@ -53,6 +53,7 @@ const allenkFdncnnRuntimePromises = new Map();
 const els = {
     dropzone: $('dropzone'),
     fileInput: $('fileInput'),
+    batchQueue: $('batchQueue'),
     comparePlayer: $('comparePlayer'),
     afterBadge: $('afterBadge'),
     playPauseBtn: $('playPauseBtn'),
@@ -672,8 +673,116 @@ async function runExport() {
     }
 }
 
+// --- Batch processing (multiple videos, one at a time) ---
+// Video decode/encode is CPU/GPU-bound, so sequential processing through the
+// existing single-file pipeline is the correct design, not a compromise.
+const batch = { queue: [], processing: false };
+
+function batchStatusLabel(status) {
+    switch (status) {
+        case 'pending': return '排队中';
+        case 'processing': return '处理中…';
+        case 'done': return '已完成 ✓';
+        case 'error': return '失败 ✗';
+        case 'skipped': return '已跳过';
+        default: return '';
+    }
+}
+
+function renderBatchQueue() {
+    const box = els.batchQueue;
+    if (!box) return;
+    if (batch.queue.length === 0) {
+        box.hidden = true;
+        box.replaceChildren();
+        return;
+    }
+    box.hidden = false;
+    box.replaceChildren(...batch.queue.map((item, index) => {
+        const row = document.createElement('div');
+        row.className = 'batch-item';
+        row.dataset.status = item.status;
+        const name = document.createElement('span');
+        name.className = 'batch-name';
+        name.textContent = `${index + 1}. ${item.file.name}`;
+        const stateLabel = document.createElement('span');
+        stateLabel.className = 'batch-state';
+        stateLabel.textContent = batchStatusLabel(item.status);
+        row.append(name, stateLabel);
+        return row;
+    }));
+}
+
+function triggerDownload(href, filename) {
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+}
+
+async function processBatch() {
+    if (batch.processing) return;
+    batch.processing = true;
+    try {
+        for (const item of batch.queue) {
+            if (item.status !== 'pending') continue;
+            item.status = 'processing';
+            renderBatchQueue();
+            try {
+                await setFile(item.file);
+                if (getDebugFileKind(item.file) !== 'video' || !state.file) {
+                    item.status = 'skipped';
+                    renderBatchQueue();
+                    continue;
+                }
+                await runExport();
+                const href = els.downloadBtn.getAttribute('href');
+                if (state.processedUrl && href) {
+                    triggerDownload(href, els.downloadBtn.getAttribute('download') || `${item.file.name}.mp4`);
+                    item.status = 'done';
+                } else {
+                    item.status = 'error';
+                }
+            } catch (error) {
+                console.error(error);
+                item.status = 'error';
+            }
+            renderBatchQueue();
+        }
+        const done = batch.queue.filter((it) => it.status === 'done').length;
+        setStatus(`批量处理完成：成功 ${done}/${batch.queue.length}，结果已自动下载。`, done ? 'success' : 'warn');
+    } finally {
+        batch.processing = false;
+    }
+}
+
+function handleIncomingFiles(fileList) {
+    const list = Array.from(fileList || []).filter(Boolean);
+    const videoFiles = list.filter((file) => getDebugFileKind(file) === 'video');
+
+    if (videoFiles.length > 1) {
+        for (const file of videoFiles) {
+            batch.queue.push({ file, status: 'pending' });
+        }
+        renderBatchQueue();
+        processBatch();
+        return;
+    }
+
+    // Single video (or an image handoff): keep the original single-file behavior
+    // so preset tuning and manual export still work.
+    const file = pickDebugUploadFile(fileList);
+    if (file) setFile(file);
+}
+
 function reset() {
     state.jobId++;
+    if (!batch.processing) {
+        batch.queue = [];
+        renderBatchQueue();
+    }
     cleanupUrls();
     state.file = null;
     state.metadata = null;
@@ -783,8 +892,7 @@ function setupEvents() {
         }
     });
     els.fileInput.addEventListener('change', (event) => {
-        const file = pickDebugUploadFile(event.target.files);
-        if (file) setFile(file);
+        handleIncomingFiles(event.target.files);
     });
 
     for (const eventName of ['dragenter', 'dragover']) {
@@ -800,8 +908,7 @@ function setupEvents() {
         });
     }
     els.dropzone.addEventListener('drop', (event) => {
-        const file = pickDebugUploadFile(event.dataTransfer?.files);
-        if (file) setFile(file);
+        handleIncomingFiles(event.dataTransfer?.files);
     });
 
     els.alphaGain.addEventListener('input', () => {

--- a/src/video/videoBatchQueue.js
+++ b/src/video/videoBatchQueue.js
@@ -1,0 +1,75 @@
+// Batch queue rules for the video page.
+//
+// Video decode/encode is CPU/GPU bound, so queued items run sequentially
+// through the existing single-file pipeline instead of in parallel. The queue
+// holds no DOM references so these rules stay unit-testable.
+
+export function createBatchQueue() {
+    return { items: [], processing: false };
+}
+
+// A completed queue must never leak into the next selection. Appending is only
+// meaningful while a batch is still running, so an idle queue is dropped here.
+export function startBatchSelection(queue) {
+    if (!queue.processing) {
+        queue.items = [];
+    }
+    return queue;
+}
+
+export function enqueueBatchFiles(queue, files) {
+    for (const file of files) {
+        queue.items.push({ file, status: 'pending' });
+    }
+    return queue;
+}
+
+export function summarizeBatch(items) {
+    return {
+        done: items.filter((item) => item.status === 'done').length,
+        total: items.length
+    };
+}
+
+export async function processBatchQueue(queue, {
+    processFile,
+    downloadResult = () => {},
+    onChange = () => {},
+    onError = () => {}
+} = {}) {
+    if (queue.processing) return null;
+    queue.processing = true;
+
+    try {
+        // Index-based so files appended while a batch runs are still picked up.
+        for (let index = 0; index < queue.items.length; index += 1) {
+            const item = queue.items[index];
+            if (item.status !== 'pending') continue;
+
+            item.status = 'processing';
+            onChange(queue);
+
+            try {
+                const outcome = await processFile(item.file);
+                if (outcome?.skipped) {
+                    item.status = 'skipped';
+                } else if (outcome?.ok && outcome.href) {
+                    item.status = 'done';
+                    downloadResult({ href: outcome.href, filename: outcome.filename });
+                } else {
+                    item.status = 'error';
+                }
+            } catch (error) {
+                // One bad file must not abort the rest of the batch.
+                onError(error, item.file);
+                item.status = 'error';
+            }
+
+            onChange(queue);
+        }
+
+        return summarizeBatch(queue.items);
+    } finally {
+        queue.processing = false;
+    }
+}

--- a/tests/video/videoBatchQueue.test.js
+++ b/tests/video/videoBatchQueue.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    createBatchQueue,
+    enqueueBatchFiles,
+    processBatchQueue,
+    startBatchSelection,
+    summarizeBatch
+} from '../../src/video/videoBatchQueue.js';
+
+const fileOf = (name) => ({ name });
+const statusesOf = (queue) => queue.items.map((item) => item.status);
+
+function exportStub(results) {
+    return async (file) => {
+        const outcome = results[file.name];
+        if (typeof outcome === 'function') return outcome(file);
+        return outcome ?? { ok: false };
+    };
+}
+
+const exported = (file) => ({ ok: true, href: `blob:${file.name}`, filename: `${file.name}.mp4` });
+
+test('a second batch replaces the completed queue instead of appending to it', async () => {
+    const queue = createBatchQueue();
+
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('good.mp4'), fileOf('bad.mp4')]);
+    const first = await processBatchQueue(queue, {
+        processFile: exportStub({ 'good.mp4': exported(fileOf('good')), 'bad.mp4': { ok: false } })
+    });
+    assert.deepEqual(first, { done: 1, total: 2 });
+
+    // Second selection of two invalid files must report 0/2, not 1/4.
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('bad-a.mp4'), fileOf('bad-b.mp4')]);
+    const second = await processBatchQueue(queue, {
+        processFile: exportStub({ 'bad-a.mp4': { ok: false }, 'bad-b.mp4': { ok: false } })
+    });
+
+    assert.equal(queue.items.length, 2);
+    assert.deepEqual(second, { done: 0, total: 2 });
+});
+
+test('returning to single-file mode clears the completed batch queue', () => {
+    const queue = createBatchQueue();
+    queue.items = [
+        { file: fileOf('done.mp4'), status: 'done' },
+        { file: fileOf('failed.mp4'), status: 'error' }
+    ];
+
+    startBatchSelection(queue);
+
+    assert.deepEqual(queue.items, []);
+    assert.deepEqual(summarizeBatch(queue.items), { done: 0, total: 0 });
+});
+
+test('a failing item does not abort the batch and the run continues', async () => {
+    const queue = createBatchQueue();
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('broken.mp4'), fileOf('fine.mp4')]);
+
+    const seen = [];
+    const summary = await processBatchQueue(queue, {
+        processFile: exportStub({
+            'broken.mp4': () => { throw new Error('decode failed'); },
+            'fine.mp4': exported(fileOf('fine'))
+        }),
+        onError: (error) => seen.push(error.message)
+    });
+
+    assert.deepEqual(statusesOf(queue), ['error', 'done']);
+    assert.deepEqual(summary, { done: 1, total: 2 });
+    assert.deepEqual(seen, ['decode failed']);
+});
+
+test('only successful items emit an automatic download', async () => {
+    const queue = createBatchQueue();
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('ok.mp4'), fileOf('bad.mp4'), fileOf('image.png')]);
+
+    const downloads = [];
+    await processBatchQueue(queue, {
+        processFile: exportStub({
+            'ok.mp4': exported(fileOf('ok')),
+            'bad.mp4': { ok: false },
+            'image.png': { skipped: true }
+        }),
+        downloadResult: (payload) => downloads.push(payload)
+    });
+
+    assert.deepEqual(statusesOf(queue), ['done', 'error', 'skipped']);
+    assert.deepEqual(downloads, [{ href: 'blob:ok', filename: 'ok.mp4' }]);
+});
+
+test('a completed queue releases its file references on the next selection', async () => {
+    const queue = createBatchQueue();
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('first.mp4')]);
+    await processBatchQueue(queue, {
+        processFile: exportStub({ 'first.mp4': exported(fileOf('first')) })
+    });
+    const stale = queue.items[0];
+
+    startBatchSelection(queue);
+
+    assert.equal(queue.items.length, 0);
+    assert.equal(queue.items.includes(stale), false);
+    assert.equal(queue.processing, false);
+});
+
+test('files selected while a batch is running are appended to the active run', async () => {
+    const queue = createBatchQueue();
+    startBatchSelection(queue);
+    enqueueBatchFiles(queue, [fileOf('a.mp4')]);
+
+    const summary = await processBatchQueue(queue, {
+        processFile: async (file) => {
+            // A selection arriving mid-run must extend the active batch.
+            if (file.name === 'a.mp4') {
+                startBatchSelection(queue);
+                enqueueBatchFiles(queue, [fileOf('b.mp4')]);
+            }
+            return exported({ name: file.name.replace('.mp4', '') });
+        }
+    });
+
+    assert.deepEqual(statusesOf(queue), ['done', 'done']);
+    assert.deepEqual(summary, { done: 2, total: 2 });
+});
+
+test('processBatchQueue refuses to start a second concurrent run', async () => {
+    const queue = createBatchQueue();
+    queue.processing = true;
+
+    const result = await processBatchQueue(queue, { processFile: async () => exported(fileOf('x')) });
+
+    assert.equal(result, null);
+});


### PR DESCRIPTION
## What

Adds support for uploading and processing **multiple videos in one go**. Until now the video page handled a single file at a time.

## How it works

- The file input now accepts `multiple`, and drag-and-drop accepts multiple files.
- Selecting or dropping more than one video queues them and processes each **sequentially** through the existing single-file pipeline (`setFile` → `runExport`), auto-downloading every result.
- A small batch-queue UI shows per-file status: `pending` / `processing` / `done` / `error`.
- Single-video selection and image handoff keep their original behavior, so preset tuning and manual export still work exactly as before.

## Why sequential (not parallel)

Video decode/encode is CPU/GPU-bound, so running one item at a time through the proven pipeline is the correct design rather than a compromise — parallel encodes would just contend for the same resources.

## Scope of changes

- `public/video-preview.html` — `multiple` on the file input + batch-queue markup and styles
- `src/video-app.js` — batch queue, sequential processing, auto-download, graceful fallback to single-file mode

No new dependencies. No changes to the watermark-removal algorithm or the single-file flow.
