### PR TITLE
Improve exact R192 best-effort watermark handling

### DIFF
--- a/scripts/alpha-profile-admission.js
+++ b/scripts/alpha-profile-admission.js
@@ -1,0 +1,35 @@
+const ABSOLUTE_BAND_CLEAN_THRESHOLD = 0.5;
+const REQUIRED_ALPHA_BANDS = Object.freeze(['edge', 'mid-core', 'high-core']);
+
+export function buildAlphaProfileAdmission({ current, trial }) {
+    const haloImproved = Number.isFinite(current.positiveHaloLum) &&
+        Number.isFinite(trial.positiveHaloLum) &&
+        trial.positiveHaloLum < current.positiveHaloLum - 0.5;
+    const gradientSafe = Number.isFinite(current.gradient) &&
+        Number.isFinite(trial.gradient) &&
+        trial.gradient <= current.gradient + 0.01;
+    const artifactSafe = Number.isFinite(current.visualArtifactCost) &&
+        Number.isFinite(trial.visualArtifactCost) &&
+        trial.visualArtifactCost <= current.visualArtifactCost + 0.001;
+    const spatialSafe = Number.isFinite(current.spatial) &&
+        Number.isFinite(trial.spatial) &&
+        Math.abs(trial.spatial) <= Math.abs(current.spatial) + 0.02;
+    const bandDeltas = REQUIRED_ALPHA_BANDS.map((band) => trial.bandProfile?.[band]?.positiveDeltaLum);
+    const maxPositiveBandDelta = bandDeltas.every(Number.isFinite)
+        ? Math.max(...bandDeltas)
+        : null;
+    const absoluteClean = trial.visible === false &&
+        trial.visiblePositiveHalo !== true &&
+        Number.isFinite(maxPositiveBandDelta) &&
+        maxPositiveBandDelta <= ABSOLUTE_BAND_CLEAN_THRESHOLD;
+
+    return {
+        productionCandidate: haloImproved && gradientSafe && artifactSafe && spatialSafe && absoluteClean,
+        haloImproved,
+        gradientSafe,
+        artifactSafe,
+        spatialSafe,
+        absoluteClean,
+        maxPositiveBandDelta
+    };
+}

--- a/scripts/diagnose-gemini-alpha-profile.js
+++ b/scripts/diagnose-gemini-alpha-profile.js
@@ -22,6 +22,7 @@ import {
     decodeImageDataInNode,
     listBenchmarkSampleAssets
 } from './sample-benchmark.js';
+import { buildAlphaProfileAdmission } from './alpha-profile-admission.js';
 
 const DEFAULT_OUTPUT_DIR = path.resolve('.artifacts/gemini-alpha-profile-diagnosis/latest');
 const SHEET_PANEL_SIZE = 190;
@@ -448,29 +449,6 @@ function buildSampleDiagnosis({ before, current, floorOnly, profileTrials, postC
     };
 }
 
-function buildAdmission({ current, trial }) {
-    const haloImproved = Number.isFinite(current.positiveHaloLum) &&
-        Number.isFinite(trial.positiveHaloLum) &&
-        trial.positiveHaloLum < current.positiveHaloLum - 0.5;
-    const gradientSafe = Number.isFinite(current.gradient) &&
-        Number.isFinite(trial.gradient) &&
-        trial.gradient <= current.gradient + 0.01;
-    const artifactSafe = Number.isFinite(current.visualArtifactCost) &&
-        Number.isFinite(trial.visualArtifactCost) &&
-        trial.visualArtifactCost <= current.visualArtifactCost + 0.001;
-    const spatialSafe = Number.isFinite(current.spatial) &&
-        Number.isFinite(trial.spatial) &&
-        Math.abs(trial.spatial) <= Math.abs(current.spatial) + 0.02;
-
-    return {
-        productionCandidate: haloImproved && gradientSafe && artifactSafe && spatialSafe,
-        haloImproved,
-        gradientSafe,
-        artifactSafe,
-        spatialSafe
-    };
-}
-
 function stripImageData(trial) {
     const { imageData, ...rest } = trial;
     return rest;
@@ -697,7 +675,7 @@ async function run() {
             });
             profileTrials.push({
                 ...trial,
-                admission: buildAdmission({ current, trial })
+                admission: buildAlphaProfileAdmission({ current, trial })
             });
         }
         const productionCandidates = profileTrials
@@ -725,7 +703,7 @@ async function run() {
             });
             postCorrectionTrials.push({
                 ...trial,
-                admission: buildAdmission({ current, trial })
+                admission: buildAlphaProfileAdmission({ current, trial })
             });
         }
         const postCorrectionCandidates = postCorrectionTrials
@@ -765,7 +743,7 @@ async function run() {
         policy: {
             reportOnly: true,
             scriptWritesProductionCode: false,
-            admissionRule: 'A profile variant is only a production candidate when halo improves by >0.5 while gradient, spatial residual, and visualArtifactCost do not increase beyond the tiny tolerance encoded in the script.'
+            admissionRule: 'A profile variant is only a production candidate when halo improves by >0.5, gradient/spatial/artifact metrics stay within tolerance, residual visibility is false, and every measured alpha band has positive delta <= 0.5 luma.'
         },
         outputDir: args.outputDir,
         sheetPath,

--- a/src/core/pipelineInitialSelection.js
+++ b/src/core/pipelineInitialSelection.js
@@ -66,6 +66,19 @@ const EXACT_48_R96_SOURCE_WITNESS_DECOY_SHIFTS = [
     [-8, 8], [-4, 4], [4, -4], [8, -8],
     [-12, -6], [-6, -12], [6, 12], [12, 6]
 ];
+const EXACT_96_R192_SOURCE_WITNESS_MIN_GRADIENT = 0.02;
+const EXACT_96_R192_SOURCE_WITNESS_MIN_EDGE_PROMINENCE = 0.2;
+const EXACT_96_R192_SOURCE_WITNESS_MIN_EDGE_PERCENTILE = 0.5;
+const EXACT_96_R192_SOURCE_WITNESS_GAIN = 0.45;
+const EXACT_96_R192_SOURCE_WITNESS_REASON =
+    'exact-96-r192-source-witness';
+const EXACT_96_R192_SOURCE_WITNESS_DECOY_SHIFTS = [
+    [-24, 0], [-16, 0], [-8, 0], [8, 0], [16, 0], [24, 0],
+    [0, -24], [0, -16], [0, -8], [0, 8], [0, 16], [0, 24],
+    [-16, -16], [-8, -8], [8, 8], [16, 16],
+    [-16, 16], [-8, 8], [8, -8], [16, -16],
+    [-24, -12], [-12, -24], [12, 24], [24, 12]
+];
 
 // The Allenk V2 renderer and the trusted 768x1376 sample cluster agree on
 // 48px / 73px geometry. Keep it out of the generic catalog because structured
@@ -254,6 +267,122 @@ function createExact48R96SourceWitnessRescueTrial({
                     sourceLocalization.twoSidedEdgeProminence,
                 gradientPercentile:
                     sourceLocalization.gradientPercentile
+            }
+        },
+        includeImageData: false
+    });
+    return measurePresenceLocalization(
+        originalImageData,
+        rescueTrial
+    ).repeatedTemplateCollision
+        ? null
+        : rescueTrial;
+}
+
+function createExact96R192SourceWitnessRescueTrial({
+    originalImageData,
+    alpha96Variants,
+    config,
+    catalogPriorConfig,
+    fixedSelection,
+    automaticSelection
+}) {
+    const alphaMap = alpha96Variants?.['20260520'];
+    if (
+        !originalImageData ||
+        !alphaMap ||
+        alphaMap.length !== 96 * 96
+    ) {
+        return null;
+    }
+
+    const catalogEntry = resolveGeminiWatermarkSearchCatalogEntries(
+        originalImageData.width,
+        originalImageData.height,
+        catalogPriorConfig ?? config
+    ).find((entry) => (
+        entry?.metadata?.evidenceGate === 'required' &&
+        entry.config?.logoSize === 96 &&
+        entry.config.marginRight === 192 &&
+        entry.config.marginBottom === 192 &&
+        entry.config.alphaVariant === '20260520'
+    ));
+    if (!catalogEntry) return null;
+
+    const position = {
+        x: originalImageData.width - 192 - 96,
+        y: originalImageData.height - 192 - 96,
+        width: 96,
+        height: 96
+    };
+    const acceptedEligibleTrials = [
+        fixedSelection?.selectedTrial,
+        automaticSelection?.selectedTrial
+    ].filter((trial, index, trials) => (
+        trial?.accepted === true &&
+        trial.evaluation?.eligible === true &&
+        trials.indexOf(trial) === index
+    ));
+    const hasDriftedDarkPolaritySelection = acceptedEligibleTrials.some(
+        (trial) => (
+            trial.provenance?.darkPolarity === true &&
+            (
+                trial.position?.x !== position.x ||
+                trial.position?.y !== position.y ||
+                trial.position?.width !== position.width ||
+                trial.position?.height !== position.height
+            )
+        )
+    );
+    if (
+        acceptedEligibleTrials.length > 0 &&
+        !hasDriftedDarkPolaritySelection
+    ) {
+        return null;
+    }
+    const sourceLocalization = measureOutputResidualLocalization({
+        imageData: originalImageData,
+        alphaMap,
+        position,
+        decoyShifts: EXACT_96_R192_SOURCE_WITNESS_DECOY_SHIFTS
+    });
+    const gradientSignal = Number(sourceLocalization.gradientSignedTarget);
+    if (
+        !Number.isFinite(gradientSignal) ||
+        gradientSignal < EXACT_96_R192_SOURCE_WITNESS_MIN_GRADIENT ||
+        Number(sourceLocalization.twoSidedEdgeProminence) <
+            EXACT_96_R192_SOURCE_WITNESS_MIN_EDGE_PROMINENCE ||
+        Number(sourceLocalization.twoSidedEdgePercentile) <
+            EXACT_96_R192_SOURCE_WITNESS_MIN_EDGE_PERCENTILE
+    ) {
+        return null;
+    }
+
+    const rescueTrial = evaluateRestorationCandidate({
+        originalImageData,
+        alphaMap,
+        position,
+        source: 'standard+catalog+source-witness-rescue',
+        config: catalogEntry.config,
+        baselineNearBlackRatio: calculateNearBlackRatio(
+            originalImageData,
+            position
+        ),
+        alphaGain: EXACT_96_R192_SOURCE_WITNESS_GAIN,
+        provenance: {
+            catalogVariant: true,
+            catalogFamily: catalogEntry.metadata.family,
+            catalogSourcePriority: catalogEntry.metadata.sourcePriority,
+            catalogEvidenceGate: catalogEntry.metadata.evidenceGate,
+            sourceWitnessRescue: true,
+            sourceWitnessReason: EXACT_96_R192_SOURCE_WITNESS_REASON,
+            sourceWitnessGate: {
+                spatialSignedTarget: sourceLocalization.spatialSignedTarget,
+                gradientSignedTarget: gradientSignal,
+                twoSidedEdgeProminence:
+                    sourceLocalization.twoSidedEdgeProminence,
+                twoSidedEdgePercentile:
+                    sourceLocalization.twoSidedEdgePercentile
             }
         },
         includeImageData: false
@@ -819,8 +948,22 @@ export function collectInitialWatermarkCandidates(input = {}) {
             config: input.config,
             catalogPriorConfig: input.catalogPriorConfig
         });
-    const bestEffortSelections = presenceConfirmed ||
+    const exact96R192SourceWitnessRescueTrial =
         exact48R96SourceWitnessRescueTrial
+            ? null
+            : createExact96R192SourceWitnessRescueTrial({
+                originalImageData: input.originalImageData,
+                alpha96Variants: input.alpha96Variants,
+                config: input.config,
+                catalogPriorConfig: input.catalogPriorConfig,
+                fixedSelection,
+                automaticSelection
+            });
+    const sourceWitnessRescueTrial =
+        exact48R96SourceWitnessRescueTrial ??
+        exact96R192SourceWitnessRescueTrial;
+    const bestEffortSelections = presenceConfirmed ||
+        sourceWitnessRescueTrial
         ? []
         : [fixedSelection, automaticSelection]
             .filter((selection, index, values) => (
@@ -831,7 +974,7 @@ export function collectInitialWatermarkCandidates(input = {}) {
                 )
             ));
     const bestEffortFallback = !presenceConfirmed && Boolean(
-        exact48R96SourceWitnessRescueTrial ||
+        sourceWitnessRescueTrial ||
         bestEffortSelections.length > 0
     );
     if (!presenceConfirmed && !bestEffortFallback) {
@@ -930,8 +1073,8 @@ export function collectInitialWatermarkCandidates(input = {}) {
         ));
     const trials = (
         bestEffortFallback
-            ? exact48R96SourceWitnessRescueTrial
-                ? [exact48R96SourceWitnessRescueTrial]
+            ? sourceWitnessRescueTrial
+                ? [sourceWitnessRescueTrial]
                 : [
                 includeFixedSelection ? fixedSelection?.selectedTrial : null,
                 includeAutomaticSelection ? automaticSelection?.selectedTrial : null,
@@ -995,24 +1138,24 @@ export function collectInitialWatermarkCandidates(input = {}) {
             : null,
         1004
     );
-    const exact48R96SourceWitnessRescueHypothesis =
+    const sourceWitnessRescueHypothesis =
         createCandidateHypothesis(
-            keepNonRepeatedTrial(exact48R96SourceWitnessRescueTrial) &&
+            keepNonRepeatedTrial(sourceWitnessRescueTrial) &&
                 isGeometryCompatibleWithLock(
-                    exact48R96SourceWitnessRescueTrial,
+                    sourceWitnessRescueTrial,
                     geometryLockWitness
                 )
-                ? exact48R96SourceWitnessRescueTrial
+                ? sourceWitnessRescueTrial
                 : null,
             1005
         );
     const preferredHypotheses = [
         fixedSelectedHypothesis,
         automaticSelectedHypothesis,
+        sourceWitnessRescueHypothesis,
         fixedPresenceHypothesis,
         automaticPresenceHypothesis,
-        confirmedV2MediumRescueHypothesis,
-        exact48R96SourceWitnessRescueHypothesis
+        confirmedV2MediumRescueHypothesis
     ].filter((hypothesis, index, values) => (
         hypothesis &&
         values.findIndex((candidate) => sameTrialIdentity(
@@ -1028,7 +1171,7 @@ export function collectInitialWatermarkCandidates(input = {}) {
     const hypotheses = [...preferredHypotheses, ...retainedAlternatives]
         .map((hypothesis) => ({
             ...hypothesis,
-            presenceStatus: exact48R96SourceWitnessRescueTrial
+            presenceStatus: sourceWitnessRescueTrial
                 ? 'source-witness'
                 : bestEffortFallback
                 ? 'selector-only'
@@ -1056,8 +1199,9 @@ export function collectInitialWatermarkCandidates(input = {}) {
         hypotheses,
         presenceConfirmed,
         bestEffortFallback,
-        bestEffortReason: exact48R96SourceWitnessRescueTrial
-            ? EXACT_48_R96_SOURCE_WITNESS_REASON
+        bestEffortReason: sourceWitnessRescueTrial
+            ? sourceWitnessRescueTrial.provenance?.sourceWitnessReason ??
+                'source-witness'
             : bestEffortFallback
             ? 'presence-witness-unconfirmed'
             : null,

--- a/src/core/watermarkProcessor.js
+++ b/src/core/watermarkProcessor.js
@@ -104,7 +104,15 @@ const NEW_MARGIN_96_FLAT_FILL_MIN_GRADIENT_IMPROVEMENT = 0.025;
 const NEW_MARGIN_96_FLAT_FILL_MAX_SPATIAL_DRIFT = 0.08;
 const NEW_MARGIN_96_FLAT_FILL_MAX_ACCEPTED_ABS_SPATIAL = 0.22;
 const NEW_MARGIN_96_FLAT_FILL_PRESETS = Object.freeze([
-    { name: 'edge', minAlpha: 0.006, maxAlpha: 0.45, strength: 0.75 }
+    { name: 'edge', minAlpha: 0.006, maxAlpha: 0.45, strength: 0.75 },
+    {
+        name: 'expanded-edge',
+        minAlpha: 0.006,
+        maxAlpha: 0.45,
+        strength: 1,
+        edgeMaskAlphaScale: 0.2,
+        minBaselineGradient: 0.6
+    }
 ]);
 const NEW_MARGIN_96_SMOOTH_EDGE_MIN_ALPHA_GAIN = 0.8;
 const NEW_MARGIN_96_SMOOTH_EDGE_MAX_ALPHA_GAIN = 0.9;
@@ -1957,6 +1965,7 @@ function applyFlatBackgroundFill({
     strength,
     maxBackgroundStd = KNOWN_48_FLAT_FILL_MAX_BACKGROUND_STD,
     edgeWeightFloor = 0.35,
+    edgeMaskAlphaScale = 0,
     pad = KNOWN_48_FLAT_FILL_PAD,
     outsideAlphaMax = KNOWN_48_FLAT_FILL_OUTSIDE_ALPHA_MAX,
     minSampleLum = 0
@@ -1989,7 +1998,12 @@ function applyFlatBackgroundFill({
         for (let col = 0; col < position.width; col++) {
             const localIndex = row * position.width + col;
             const alpha = alphaMap[localIndex];
-            if (alpha < minAlpha || alpha > maxAlpha) continue;
+            const edgeWeight = getAlphaGradientWeight(edgeMask, localIndex, edgeWeightFloor);
+            const repairAlpha = Math.max(
+                alpha,
+                Number(edgeMask[localIndex] ?? 0) * edgeMaskAlphaScale
+            );
+            if (repairAlpha < minAlpha || repairAlpha > maxAlpha) continue;
 
             const x = col / Math.max(1, position.width);
             const y = row / Math.max(1, position.height);
@@ -1999,8 +2013,10 @@ function applyFlatBackgroundFill({
                 bluePlane[0] + bluePlane[1] * x + bluePlane[2] * y
             ];
             const pixelIndex = ((position.y + row) * candidate.width + position.x + col) * 4;
-            const edgeWeight = getAlphaGradientWeight(edgeMask, localIndex, edgeWeightFloor);
-            const blend = Math.max(0, Math.min(1, strength * Math.min(1, alpha / 0.2) * edgeWeight));
+            const blend = Math.max(0, Math.min(
+                1,
+                strength * Math.min(1, repairAlpha / 0.2) * edgeWeight
+            ));
             for (let channel = 0; channel < 3; channel++) {
                 candidate.data[pixelIndex + channel] = clampChannel(
                     candidate.data[pixelIndex + channel] * (1 - blend) + target[channel] * blend
@@ -2164,6 +2180,12 @@ function refineNewMargin96FlatBackgroundResidual({
 
     let best = null;
     for (const preset of NEW_MARGIN_96_FLAT_FILL_PRESETS) {
+        if (
+            Number.isFinite(preset.minBaselineGradient) &&
+            baselineGradientScore < preset.minBaselineGradient
+        ) {
+            continue;
+        }
         const filled = applyFlatBackgroundFill({
             sourceImageData,
             alphaMap,

--- a/tests/core/watermarkProcessor.test.js
+++ b/tests/core/watermarkProcessor.test.js
@@ -95,6 +95,142 @@ function measureIssue111ReferenceDelta(actual, expected) {
     };
 }
 
+function createSolidImageData(width, height, color) {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let index = 0; index < data.length; index += 4) {
+        data[index] = color[0];
+        data[index + 1] = color[1];
+        data[index + 2] = color[2];
+        data[index + 3] = 255;
+    }
+    return { width, height, data };
+}
+
+function paintIssue120DiagonalStripe(imageData, position) {
+    for (let row = -32; row < 128; row++) {
+        for (let col = -32; col < 128; col++) {
+            if (Math.abs(row - (-col + 20)) > 6) continue;
+            const x = position.x + col;
+            const y = position.y + row;
+            if (x < 0 || y < 0 || x >= imageData.width || y >= imageData.height) continue;
+            const index = (y * imageData.width + x) * 4;
+            imageData.data[index] = 35;
+            imageData.data[index + 1] = 58;
+            imageData.data[index + 2] = 70;
+        }
+    }
+}
+
+function fillIssue120Rect(imageData, x, y, width, height, color) {
+    for (let row = y; row < y + height; row++) {
+        for (let col = x; col < x + width; col++) {
+            const index = (row * imageData.width + col) * 4;
+            imageData.data[index] = color[0];
+            imageData.data[index + 1] = color[1];
+            imageData.data[index + 2] = color[2];
+        }
+    }
+}
+
+function paintIssue120LetterE(imageData, x, y) {
+    const color = [24, 45, 64];
+    fillIssue120Rect(imageData, x, y, 8, 52, color);
+    fillIssue120Rect(imageData, x, y, 30, 8, color);
+    fillIssue120Rect(imageData, x, y + 22, 25, 8, color);
+    fillIssue120Rect(imageData, x, y + 44, 30, 8, color);
+}
+
+function measureRegionMeanAbsoluteDelta(actual, expected, position) {
+    let sum = 0;
+    let count = 0;
+    for (let row = 0; row < position.height; row++) {
+        for (let col = 0; col < position.width; col++) {
+            const index = ((position.y + row) * actual.width + position.x + col) * 4;
+            for (let channel = 0; channel < 3; channel++) {
+                sum += Math.abs(actual.data[index + channel] - expected.data[index + channel]);
+                count++;
+            }
+        }
+    }
+    return sum / Math.max(1, count);
+}
+
+test('processWatermarkImageData should best-effort rescue an exact 96px new-margin source witness over structured content', () => {
+    const position = { x: 2464, y: 1248, width: 96, height: 96 };
+    const alphaMap = getEmbeddedAlphaMap('96-20260520');
+    const clean = createSolidImageData(2752, 1536, [201, 239, 235]);
+    paintIssue120DiagonalStripe(clean, position);
+    const watermarked = cloneImageDataForIssue111(clean);
+    applySyntheticWatermark(watermarked, alphaMap, position);
+    const beforeDelta = measureRegionMeanAbsoluteDelta(watermarked, clean, position);
+
+    const result = removeWatermarkFromImageDataSync(watermarked, { debugTimings: true });
+    const afterDelta = measureRegionMeanAbsoluteDelta(result.imageData, clean, position);
+
+    assert.equal(result.meta.applied, true, `skipReason=${result.meta.skipReason}`);
+    assert.deepEqual(result.meta.config, {
+        logoSize: 96,
+        marginRight: 192,
+        marginBottom: 192,
+        alphaVariant: '20260520'
+    });
+    assert.deepEqual(result.meta.position, position);
+    assert.equal(result.meta.alphaGain, 0.45);
+    assert.equal(result.meta.presenceConfirmed, false);
+    assert.equal(result.meta.bestEffort, true);
+    assert.equal(result.meta.bestEffortReason, 'exact-96-r192-source-witness');
+    assert.match(result.meta.source, /source-witness-rescue/);
+    assert.ok(afterDelta < beforeDelta * 0.7, `before=${beforeDelta}, after=${afterDelta}`);
+});
+
+test('processWatermarkImageData should prefer a conservative exact source witness over a damaging shifted dark candidate', () => {
+    const position = { x: 2464, y: 1248, width: 96, height: 96 };
+    const alphaMap = getEmbeddedAlphaMap('96-20260520');
+    const clean = createSolidImageData(2752, 1536, [201, 239, 235]);
+    fillIssue120Rect(clean, 2380, 1212, 260, 150, [249, 250, 248]);
+    paintIssue120LetterE(clean, 2484, 1268);
+    const watermarked = cloneImageDataForIssue111(clean);
+    applySyntheticWatermark(watermarked, alphaMap, position);
+
+    const result = removeWatermarkFromImageDataSync(watermarked);
+    const roiDelta = measureRegionMeanAbsoluteDelta(result.imageData, clean, position);
+    const contentDelta = measureRegionMeanAbsoluteDelta(result.imageData, clean, {
+        x: 2484,
+        y: 1268,
+        width: 30,
+        height: 52
+    });
+
+    assert.match(result.meta.source, /source-witness-rescue/);
+    assert.deepEqual(result.meta.position, position);
+    assert.equal(result.meta.alphaGain, 0.45);
+    assert.equal(result.meta.qualitySignals?.damageWarning, false);
+    assert.ok(roiDelta <= 5, `roiDelta=${roiDelta}, source=${result.meta.source}`);
+    assert.ok(contentDelta <= 25, `contentDelta=${contentDelta}, source=${result.meta.source}`);
+});
+
+test('processWatermarkImageData should repair expanded new-margin alpha edges on a flat background', () => {
+    const position = { x: 2464, y: 1248, width: 96, height: 96 };
+    const alphaMap = getEmbeddedAlphaMap('96-20260520');
+    const expandedAlphaMap = warpAlphaMap(alphaMap, 96, { scale: 1.03 });
+    const clean = createSolidImageData(2752, 1536, [201, 239, 235]);
+    const watermarked = cloneImageDataForIssue111(clean);
+    applySyntheticWatermark(watermarked, expandedAlphaMap, position);
+
+    const result = removeWatermarkFromImageDataSync(watermarked);
+    const afterDelta = measureRegionMeanAbsoluteDelta(result.imageData, clean, position);
+
+    assert.equal(result.meta.applied, true, `skipReason=${result.meta.skipReason}`);
+    assert.deepEqual(result.meta.position, position);
+    assert.ok(
+        result.meta.alphaAdjustmentStages?.some((stage) =>
+            stage.stage === 'new-margin-96-flat-background-fill'
+        ),
+        JSON.stringify(result.meta.alphaAdjustmentStages)
+    );
+    assert.ok(afterDelta <= 0.08, `afterDelta=${afterDelta}`);
+});
+
 test('processWatermarkImageData should run in Node without asset imports and record single-pass meta', () => {
     const alpha96 = createSyntheticAlphaMap(96);
     const alpha48 = interpolateAlphaMap(alpha96, 96, 48);

--- a/tests/scripts/alphaProfileAdmission.test.js
+++ b/tests/scripts/alphaProfileAdmission.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const admissionModule = await import('../../scripts/alpha-profile-admission.js').catch(() => ({}));
+
+test('alpha profile admission promotes only trials that are relatively safer and absolutely clean', () => {
+    assert.equal(typeof admissionModule.buildAlphaProfileAdmission, 'function');
+
+    const current = {
+        spatial: 0.18,
+        gradient: 0.05,
+        positiveHaloLum: 12,
+        visualArtifactCost: 0.08
+    };
+    const relativelyImprovedButVisible = {
+        spatial: 0.17,
+        gradient: 0.04,
+        positiveHaloLum: 10,
+        visualArtifactCost: 0.07,
+        visible: true,
+        visiblePositiveHalo: true,
+        bandProfile: {
+            edge: { positiveDeltaLum: 0 },
+            'mid-core': { positiveDeltaLum: 10 },
+            'high-core': { positiveDeltaLum: 14 }
+        }
+    };
+    const relativelyImprovedAndClean = {
+        spatial: 0.02,
+        gradient: 0.03,
+        positiveHaloLum: 0.3,
+        visualArtifactCost: 0.04,
+        visible: false,
+        visiblePositiveHalo: false,
+        bandProfile: {
+            edge: { positiveDeltaLum: 0.2 },
+            'mid-core': { positiveDeltaLum: 0.3 },
+            'high-core': { positiveDeltaLum: 0.4 }
+        }
+    };
+
+    const visibleAdmission = admissionModule.buildAlphaProfileAdmission({
+        current,
+        trial: relativelyImprovedButVisible
+    });
+    const cleanAdmission = admissionModule.buildAlphaProfileAdmission({
+        current,
+        trial: relativelyImprovedAndClean
+    });
+
+    assert.equal(visibleAdmission.productionCandidate, false);
+    assert.equal(visibleAdmission.absoluteClean, false);
+    assert.equal(cleanAdmission.productionCandidate, true);
+    assert.equal(cleanAdmission.absoluteClean, true);
+});


### PR DESCRIPTION
## Summary

- improve conservative exact R192 best-effort handling for issue #120
- prefer a safe exact white-polarity candidate when a drifted dark-polarity candidate would damage content
- harden alpha-profile diagnostic admission with independent visible-residual and signed halo checks

## Root cause

Issue #120 is not primarily a missing catalog anchor or global alpha-strength problem. All 14 samples use the evidence-gated 96px watermark at a 192px right/bottom margin. Flat-background alpha inference shows the template body gain is already close to correct; the mismatch is concentrated in variable low-alpha contour support.

One complex sample also selected a shifted dark-polarity content feature, clipping nearby text. The exact R192 source witness provides a safer best-effort alternative. The alpha-profile investigation additionally showed that relative self-selected score improvement alone can admit visibly dirty candidates, so diagnostic promotion now requires independent residual checks.

## Impact

- output coverage on the issue corpus improves from 11/14 to 14/14
- the shipping sample moves from content damage (~3.55% newly clipped pixels) to a conservative residual with 0 newly clipped pixels
- the strict diagnostic pass count remains 3/14
- strict alpha-profile admission now promotes 0/14 candidates, preventing unsupported contour-profile changes from reaching production
- issue #120 remains open pending independently gated contour-profile evidence and the reporter's remaining same-batch controls

## Stack

This is the third PR in the split stack:

1. #126 V2 medium rescue -> merged into `main`
2. #127 exact watermark rescue -> merged into `main`
3. this PR -> `main`

This PR now contains only rebased commits `2cf1f6d` and `366b0ef`. The already-merged predecessor layers were dropped before retargeting to `main`.

## Validation

- modified core tests: 114 total, 89 passed, 25 skipped for unavailable external fixtures, 0 failed
- page/project/runtime/scripts/SDK/shared/userscript/worker tests passed
- script suite: 628/628 passed after the alpha-profile admission change
- production build passed
- `git diff --check` passed
- strict 14-sample alpha-profile rerun: 0 unsupported production candidates admitted
- rebased diff remains 6 files, 413 additions, and 43 deletions; the branch update uses `--force-with-lease` against old head `edd70a0`

Closes no issue; follow-up evidence is tracked in #120.
