### PR TITLE
Automate GitHub issue sample verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Notes:
 - The root path `/` is now a lightweight entry page that points to the official website, the userscript artifact, and the retained internal preview page.
 - The internal browser preview harness lives at `/dev-preview.html`, is now kept as a static Chinese-only single-image compare harness for local algorithm/UI debugging, and no longer maintains public-facing locale or theme-switching features.
 - `pnpm dev` / `pnpm serve` still host the userscript, probe pages, and these static assets.
+- For GitHub issues with Release-hosted samples, `pnpm issue:verify -- --issue <number>` reuses the `gh` login, caches and verifies the samples, and generates a reviewable comment draft. See [GitHub issue sample verification](docs/github-issue-verification.zh.md).
 
 ### Tampermonkey Debugging on macOS
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -187,6 +187,7 @@ pnpm serve
 - 根路径 `/` 现在是轻量入口页，只负责引导到官网、userscript 安装地址和仓库内保留的内部预览页。
 - 内部浏览器预览页位于 `/dev-preview.html`，当前保留为中文静态单图对比 harness，用于本地算法/UI 调试，不再作为对外开发者预览站，也不再维护多语言和主题切换。
 - `pnpm dev` / `pnpm serve` 仍会提供 userscript、probe 页面和这些静态资产。
+- 跟进附带 Release 样本的 GitHub issue 时，可用 `pnpm issue:verify -- --issue <编号>` 复用登录态、缓存样本、核验摘要并生成评论草稿；详见 [GitHub Issue 样本复核](docs/github-issue-verification.zh.md)。
 
 ### macOS 下调试油猴固定 Profile
 

--- a/docs/github-issue-verification.zh.md
+++ b/docs/github-issue-verification.zh.md
@@ -1,0 +1,37 @@
+# GitHub Issue 样本复核
+
+对附带 GitHub Release 样本的反馈 issue，优先使用统一命令完成取样、摘要核验、基准运行和评论草稿生成：
+
+```bash
+pnpm issue:verify -- --issue 120
+```
+
+命令会通过当前 `gh` keyring 登录态读取 issue，解析正文中的第一个 GitHub Release 链接，把图片资源缓存到 `.artifacts/github-issues/`，并对 Release API 提供的 SHA-256 逐文件复核。摘要匹配的缓存会直接复用；缺失或不匹配的资源会重新下载并再次核验。
+
+默认只在本地生成以下证据，不写 GitHub：
+
+- `latest.json`：issue、来源、资源摘要、指标和产物清单
+- `benchmark-report.json` / `benchmark-report.md`：外部样本基准
+- `benchmark-results.csv` / `benchmark-failures.csv`：逐样本结果
+- `comment.md`：可审阅的 GitHub 评论草稿
+
+确认草稿后，只有显式传入 `--comment` 才会发布：
+
+```bash
+pnpm issue:verify -- --issue 120 --comment
+```
+
+其他常用参数：
+
+```bash
+# 指定仓库
+pnpm issue:verify -- --repo owner/repo --issue 120
+
+# 使用本地样本；此模式无法核验 GitHub Release 摘要
+pnpm issue:verify -- --issue 120 --sample-root path/to/samples
+
+# 与既有基准报告比较
+pnpm issue:verify -- --issue 120 --baseline path/to/baseline.json
+```
+
+该流程使用 `--assume-watermarked` 运行现有外部样本基准，因此结果属于可复现的诊断证据，不自动等同于人工标注的发布门禁，也不会自动关闭 issue。

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "probe:real-page:copy-download": "node scripts/real-page-copy-download-probe.js",
     "benchmark:samples": "node scripts/sample-benchmark.js",
     "benchmark:userscript": "node scripts/userscript-benchmark.js",
+    "issue:verify": "node scripts/verify-github-issue.js",
     "benchmark:online-sample:gate": "node scripts/gate-online-gemini-watermark-sample-benchmark.js",
     "report:online-sample:remaining-audit": "node scripts/audit-online-tier-a-remaining.js",
     "report:online-sample:remaining-taxonomy": "node scripts/create-online-sample-remaining-failure-taxonomy.js",

--- a/scripts/verify-github-issue.js
+++ b/scripts/verify-github-issue.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+
+import { execFile as execFileCallback } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFileCallback);
+const IMAGE_ASSET_PATTERN = /\.(?:avif|gif|jpe?g|png|webp)$/i;
+const BENCHMARK_SCRIPT = 'scripts/run-external-gemini-watermark-sample-benchmark.js';
+
+export const HELP_TEXT = `Usage:
+  pnpm issue:verify -- --issue <number> [options]
+
+Options:
+  --repo <owner/repo>       GitHub repository (defaults to current repository)
+  --sample-root <path>      Reuse a local sample directory instead of release assets
+  --output-dir <path>       Override the artifact directory
+  --baseline <path>         Compare with an existing benchmark report
+  --comment                 Publish the generated comment draft to the issue
+  --help                    Show this help
+`;
+
+function readOptionValue(args, index, option) {
+    const value = args[index + 1];
+    if (!value || value === '--' || value.startsWith('--')) {
+        throw new Error(`${option} requires a value`);
+    }
+    return value;
+}
+
+export function parseIssueVerificationArgs(argv = process.argv.slice(2)) {
+    const parsed = {
+        issue: null,
+        repo: null,
+        sampleRoot: null,
+        outputDir: null,
+        baseline: null,
+        comment: false,
+        help: false
+    };
+    const args = argv.filter((arg) => arg !== '--');
+
+    for (let index = 0; index < args.length; index += 1) {
+        const arg = args[index];
+        if (arg === '--help' || arg === '-h') {
+            parsed.help = true;
+        } else if (arg === '--comment') {
+            parsed.comment = true;
+        } else if (arg === '--issue') {
+            const value = readOptionValue(args, index, arg);
+            parsed.issue = Number(value);
+            index += 1;
+        } else if (arg === '--repo') {
+            parsed.repo = readOptionValue(args, index, arg);
+            index += 1;
+        } else if (arg === '--sample-root') {
+            parsed.sampleRoot = path.resolve(readOptionValue(args, index, arg));
+            index += 1;
+        } else if (arg === '--output-dir') {
+            parsed.outputDir = path.resolve(readOptionValue(args, index, arg));
+            index += 1;
+        } else if (arg === '--baseline') {
+            parsed.baseline = path.resolve(readOptionValue(args, index, arg));
+            index += 1;
+        } else {
+            throw new Error(`unknown option: ${arg}`);
+        }
+    }
+
+    if (!parsed.help && (!Number.isInteger(parsed.issue) || parsed.issue <= 0)) {
+        throw new Error('--issue must be a positive integer');
+    }
+    if (parsed.repo && !/^[^/\s]+\/[^/\s]+$/.test(parsed.repo)) {
+        throw new Error('--repo must use owner/repo format');
+    }
+    return parsed;
+}
+
+export function extractGithubReleaseReferences(body = '') {
+    const pattern = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/releases\/tag\/([^\s)<>'"]+)/gi;
+    const references = [];
+    const seen = new Set();
+    for (const match of body.matchAll(pattern)) {
+        const url = match[0].replace(/[.,;:!?]+$/, '');
+        if (seen.has(url)) continue;
+        seen.add(url);
+        const parsed = new URL(url);
+        const [, owner, repo, , , encodedTag] = parsed.pathname.split('/');
+        references.push({
+            owner,
+            repo,
+            tag: decodeURIComponent(encodedTag),
+            url
+        });
+    }
+    return references;
+}
+
+async function fileExists(filePath) {
+    try {
+        await access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function sha256File(filePath) {
+    const bytes = await readFile(filePath);
+    return createHash('sha256').update(bytes).digest('hex');
+}
+
+function expectedSha256(digest) {
+    const match = /^sha256:([a-f0-9]{64})$/i.exec(digest ?? '');
+    return match ? match[1].toLowerCase() : null;
+}
+
+function validateAssetName(name) {
+    if (!name || path.basename(name) !== name || name === '.' || name === '..') {
+        throw new Error(`unsafe release asset name: ${name}`);
+    }
+}
+
+export async function inspectReleaseAssets(assets, sampleRoot) {
+    const imageAssets = assets.filter(({ name }) => IMAGE_ASSET_PATTERN.test(name ?? ''));
+    const results = [];
+    for (const asset of imageAssets) {
+        validateAssetName(asset.name);
+        const filePath = path.join(sampleRoot, asset.name);
+        const expectedDigest = expectedSha256(asset.digest);
+        if (!await fileExists(filePath)) {
+            results.push({ ...asset, filePath, expectedDigest, actualDigest: null, status: 'missing' });
+            continue;
+        }
+        const actualDigest = await sha256File(filePath);
+        const status = expectedDigest === null
+            ? 'unverified'
+            : actualDigest === expectedDigest ? 'verified' : 'mismatch';
+        results.push({ ...asset, filePath, expectedDigest, actualDigest, status });
+    }
+    return results;
+}
+
+async function resolveCurrentRepo(execFile) {
+    const { stdout } = await execFile('gh', [
+        'repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'
+    ], { encoding: 'utf8' });
+    return stdout.trim();
+}
+
+async function fetchIssue(execFile, repo, issueNumber) {
+    const { stdout } = await execFile('gh', [
+        'issue', 'view', String(issueNumber), '--repo', repo,
+        '--json', 'number,title,url,body,state'
+    ], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
+    return JSON.parse(stdout);
+}
+
+async function fetchRelease(execFile, reference) {
+    const endpoint = `repos/${reference.owner}/${reference.repo}/releases/tags/${encodeURIComponent(reference.tag)}`;
+    const { stdout } = await execFile('gh', ['api', endpoint], {
+        encoding: 'utf8',
+        maxBuffer: 10 * 1024 * 1024
+    });
+    return JSON.parse(stdout);
+}
+
+async function prepareReleaseSamples({ execFile, reference, sampleRoot }) {
+    const release = await fetchRelease(execFile, reference);
+    const assets = (release.assets ?? []).filter(({ name }) => IMAGE_ASSET_PATTERN.test(name ?? ''));
+    if (assets.length === 0) {
+        throw new Error(`release has no supported image assets: ${reference.url}`);
+    }
+    await mkdir(sampleRoot, { recursive: true });
+
+    let inspection = await inspectReleaseAssets(assets, sampleRoot);
+    for (const asset of inspection.filter(({ status }) => status === 'missing' || status === 'mismatch')) {
+        if (asset.status === 'mismatch') {
+            await rm(asset.filePath, { force: true });
+        }
+        await execFile('gh', [
+            'release', 'download', reference.tag,
+            '--repo', `${reference.owner}/${reference.repo}`,
+            '--pattern', asset.name,
+            '--dir', sampleRoot,
+            '--clobber'
+        ], { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
+    }
+
+    inspection = await inspectReleaseAssets(assets, sampleRoot);
+    const invalid = inspection.filter(({ status }) => status === 'missing' || status === 'mismatch');
+    if (invalid.length > 0) {
+        throw new Error(`release asset verification failed: ${invalid.map(({ name, status }) => `${name}=${status}`).join(', ')}`);
+    }
+    return { release, assets: inspection };
+}
+
+function formatRatio(metric) {
+    if (!metric) return 'n/a';
+    return `${metric.numerator ?? 0}/${metric.denominator ?? 0}`;
+}
+
+function escapeMarkdownLinkText(value) {
+    return String(value ?? '').replace(/([\\\[\]])/g, '\\$1');
+}
+
+export function renderIssueVerificationComment({ issue, source, report }) {
+    const summary = report.summary ?? {};
+    const metrics = report.metrics ?? {};
+    const bucketSummary = Object.entries(summary.buckets ?? {})
+        .map(([name, count]) => `${name}=${count}`)
+        .join(', ') || 'none';
+    const sourceLine = source.kind === 'release'
+        ? `[GitHub Release](${source.url})（SHA-256 已核验 ${source.verifiedAssetCount}/${source.imageAssetCount} 个图片资源）`
+        : `本地样本目录（未进行 GitHub Release 摘要核验）`;
+
+    return `## 自动复核结果
+
+- Issue: [#${issue.number} ${escapeMarkdownLinkText(issue.title)}](${issue.url})
+- 样本来源: ${sourceLine}
+- 数据集模式: \`${report.dataset?.mode ?? 'unknown'}\`
+- 内容集合 SHA-256: \`${report.dataset?.contentSetSha256 ?? 'unknown'}\`
+- 检测覆盖: ${formatRatio(metrics.watermarkDetectionRecall)}
+- 端到端通过: ${formatRatio(metrics.watermarkEndToEndPassRate)}
+- 基准汇总: pass=${summary.passCount ?? 0}, fail=${summary.failCount ?? 0}, excluded=${summary.excludedCount ?? 0}, total=${summary.total ?? 0}
+- 失败分类: ${bucketSummary}
+
+这是可复现的自动化证据；\`assumed-watermarked\` 数据不等同于人工标注的发布门禁。该命令不会自动关闭 issue，仍需结合可视化审查判断后续状态。
+`;
+}
+
+async function runExternalBenchmark({ execFile, cwd, sampleRoot, outputPath, markdownPath, resultsCsvPath, failuresCsvPath, baseline }) {
+    const args = [
+        BENCHMARK_SCRIPT,
+        '--sample-root', sampleRoot,
+        '--output', outputPath,
+        '--markdown', markdownPath,
+        '--results-csv', resultsCsvPath,
+        '--failures-csv', failuresCsvPath,
+        '--assume-watermarked'
+    ];
+    if (baseline) args.push('--baseline', baseline);
+    await execFile(process.execPath, args, {
+        cwd,
+        encoding: 'utf8',
+        maxBuffer: 20 * 1024 * 1024
+    });
+}
+
+function defaultOutputDir(cwd, repo, issueNumber) {
+    const safeRepo = repo.replace(/[^a-z0-9._-]+/gi, '-');
+    return path.join(cwd, '.artifacts', 'github-issues', `${safeRepo}-issue-${issueNumber}`);
+}
+
+export async function runIssueVerification(options, dependencies = {}) {
+    const execFile = dependencies.execFile ?? execFileAsync;
+    const benchmarkRunner = dependencies.benchmarkRunner ?? runExternalBenchmark;
+    const cwd = path.resolve(dependencies.cwd ?? process.cwd());
+    const repo = options.repo ?? await resolveCurrentRepo(execFile);
+    const issue = await fetchIssue(execFile, repo, options.issue);
+    const outputDir = path.resolve(options.outputDir ?? defaultOutputDir(cwd, repo, issue.number));
+    await mkdir(outputDir, { recursive: true });
+
+    let sampleRoot;
+    let source;
+    if (options.sampleRoot) {
+        sampleRoot = path.resolve(options.sampleRoot);
+        source = { kind: 'local', sampleRoot };
+    } else {
+        const references = extractGithubReleaseReferences(issue.body);
+        if (references.length === 0) {
+            throw new Error('issue body has no GitHub Release link; pass --sample-root explicitly');
+        }
+        const reference = references[0];
+        sampleRoot = path.join(outputDir, 'samples', `${reference.owner}-${reference.repo}-${reference.tag.replace(/[^a-z0-9._-]+/gi, '-')}`);
+        const prepared = await prepareReleaseSamples({ execFile, reference, sampleRoot });
+        source = {
+            kind: 'release',
+            url: reference.url,
+            owner: reference.owner,
+            repo: reference.repo,
+            tag: reference.tag,
+            releaseId: prepared.release.id ?? null,
+            imageAssetCount: prepared.assets.length,
+            verifiedAssetCount: prepared.assets.filter(({ status }) => status === 'verified').length,
+            unverifiedAssetCount: prepared.assets.filter(({ status }) => status === 'unverified').length,
+            assets: prepared.assets.map(({ name, expectedDigest, actualDigest, status }) => ({
+                name,
+                expectedDigest,
+                actualDigest,
+                status
+            }))
+        };
+    }
+
+    const outputPath = path.join(outputDir, 'benchmark-report.json');
+    const markdownPath = path.join(outputDir, 'benchmark-report.md');
+    const resultsCsvPath = path.join(outputDir, 'benchmark-results.csv');
+    const failuresCsvPath = path.join(outputDir, 'benchmark-failures.csv');
+    await benchmarkRunner({
+        execFile,
+        cwd,
+        sampleRoot,
+        outputPath,
+        markdownPath,
+        resultsCsvPath,
+        failuresCsvPath,
+        baseline: options.baseline
+    });
+
+    const report = JSON.parse(await readFile(outputPath, 'utf8'));
+    const commentMarkdown = renderIssueVerificationComment({ issue, source, report });
+    const commentPath = path.join(outputDir, 'comment.md');
+    await writeFile(commentPath, commentMarkdown, 'utf8');
+
+    const result = {
+        generatedAt: new Date().toISOString(),
+        repo,
+        issue,
+        source,
+        sampleRoot,
+        outputDir,
+        artifacts: {
+            report: outputPath,
+            markdown: markdownPath,
+            resultsCsv: resultsCsvPath,
+            failuresCsv: failuresCsvPath,
+            comment: commentPath
+        },
+        summary: report.summary,
+        metrics: report.metrics,
+        commentPublished: false,
+        commentUrl: null
+    };
+
+    if (options.comment) {
+        const { stdout } = await execFile('gh', [
+            'issue', 'comment', String(issue.number), '--repo', repo, '--body-file', commentPath
+        ], { encoding: 'utf8' });
+        result.commentPublished = true;
+        result.commentUrl = stdout.trim() || null;
+    }
+
+    const manifestPath = path.join(outputDir, 'latest.json');
+    result.artifacts.manifest = manifestPath;
+    await writeFile(manifestPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+    return result;
+}
+
+async function main() {
+    const options = parseIssueVerificationArgs();
+    if (options.help) {
+        process.stdout.write(HELP_TEXT);
+        return;
+    }
+    const result = await runIssueVerification(options);
+    const summary = result.summary ?? {};
+    process.stdout.write(`issue: ${result.repo}#${result.issue.number}\n`);
+    process.stdout.write(`summary: pass=${summary.passCount ?? 0} fail=${summary.failCount ?? 0} total=${summary.total ?? 0}\n`);
+    process.stdout.write(`artifacts: ${result.outputDir}\n`);
+    process.stdout.write(result.commentPublished
+        ? `comment: ${result.commentUrl ?? 'published'}\n`
+        : `comment draft: ${result.artifacts.comment}\n`);
+}
+
+const isDirectRun = process.argv[1]
+    && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error(error?.stack ?? error);
+        process.exitCode = 1;
+    });
+}

--- a/tests/scripts/githubIssueVerification.test.js
+++ b/tests/scripts/githubIssueVerification.test.js
@@ -1,0 +1,239 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import * as verification from '../../scripts/verify-github-issue.js';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'verify-github-issue.js');
+
+test('issue verification CLI exposes a help entry point without contacting GitHub', () => {
+    const result = spawnSync(process.execPath, [scriptPath, '--help'], {
+        cwd: repoRoot,
+        encoding: 'utf8'
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /pnpm issue:verify -- --issue <number>/);
+    assert.match(result.stdout, /--comment/);
+});
+
+test('parseIssueVerificationArgs accepts pnpm forwarding and keeps publication opt-in', () => {
+    assert.equal(typeof verification.parseIssueVerificationArgs, 'function');
+    const parsed = verification.parseIssueVerificationArgs([
+        '--',
+        '--issue', '120',
+        '--repo', 'GargantuaX/gemini-watermark-remover',
+        '--baseline', '.artifacts/baseline.json'
+    ]);
+
+    assert.equal(parsed.issue, 120);
+    assert.equal(parsed.repo, 'GargantuaX/gemini-watermark-remover');
+    assert.equal(parsed.comment, false);
+    assert.match(parsed.baseline, /\.artifacts[\\/]baseline\.json$/);
+});
+
+test('extractGithubReleaseReferences finds and decodes linked GitHub releases once', () => {
+    assert.equal(typeof verification.extractGithubReleaseReferences, 'function');
+    const references = verification.extractGithubReleaseReferences(`
+Samples: https://github.com/esfomeado/gwr-bug-samples/releases/tag/v1
+Duplicate: https://github.com/esfomeado/gwr-bug-samples/releases/tag/v1
+Encoded: https://github.com/acme/assets/releases/tag/issue%2F120
+    `);
+
+    assert.deepEqual(references, [
+        {
+            owner: 'esfomeado',
+            repo: 'gwr-bug-samples',
+            tag: 'v1',
+            url: 'https://github.com/esfomeado/gwr-bug-samples/releases/tag/v1'
+        },
+        {
+            owner: 'acme',
+            repo: 'assets',
+            tag: 'issue/120',
+            url: 'https://github.com/acme/assets/releases/tag/issue%2F120'
+        }
+    ]);
+});
+
+test('inspectReleaseAssets verifies cached image bytes and reports missing or mismatched assets', async () => {
+    assert.equal(typeof verification.inspectReleaseAssets, 'function');
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gwr-issue-verification-'));
+    try {
+        const goodBytes = Buffer.from('verified-image');
+        await writeFile(path.join(tempRoot, 'good.png'), goodBytes);
+        await writeFile(path.join(tempRoot, 'bad.jpg'), 'wrong-bytes');
+        const goodDigest = createHash('sha256').update(goodBytes).digest('hex');
+
+        const inspected = await verification.inspectReleaseAssets([
+            { name: 'good.png', digest: `sha256:${goodDigest}` },
+            { name: 'bad.jpg', digest: `sha256:${'0'.repeat(64)}` },
+            { name: 'missing.webp', digest: `sha256:${'1'.repeat(64)}` },
+            { name: 'notes.txt', digest: `sha256:${'2'.repeat(64)}` }
+        ], tempRoot);
+
+        assert.deepEqual(inspected.map(({ name, status }) => ({ name, status })), [
+            { name: 'good.png', status: 'verified' },
+            { name: 'bad.jpg', status: 'mismatch' },
+            { name: 'missing.webp', status: 'missing' }
+        ]);
+    } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+});
+
+test('renderIssueVerificationComment reports evidence without claiming the issue is fixed', () => {
+    assert.equal(typeof verification.renderIssueVerificationComment, 'function');
+    const markdown = verification.renderIssueVerificationComment({
+        issue: { number: 120, title: '[Bug] Watermark not removed', url: 'https://github.test/issues/120' },
+        source: {
+            kind: 'release',
+            url: 'https://github.com/esfomeado/gwr-bug-samples/releases/tag/v1',
+            verifiedAssetCount: 14,
+            imageAssetCount: 14
+        },
+        report: {
+            dataset: { mode: 'assumed-watermarked', contentSetSha256: 'abc123' },
+            summary: {
+                total: 14,
+                passCount: 3,
+                failCount: 11,
+                excludedCount: 0,
+                buckets: { pass: 3, 'residual-edge': 11 }
+            },
+            metrics: {
+                watermarkDetectionRecall: { numerator: 14, denominator: 14, rate: 1 },
+                watermarkEndToEndPassRate: { numerator: 3, denominator: 14, rate: 0.2143 }
+            }
+        }
+    });
+
+    assert.match(markdown, /14\/14/);
+    assert.match(markdown, /3\/14/);
+    assert.match(markdown, /assumed-watermarked/);
+    assert.match(markdown, /不会自动关闭 issue/);
+    assert.doesNotMatch(markdown, /已修复/);
+    assert.ok(markdown.includes('[#120 \\[Bug\\] Watermark not removed]('));
+});
+
+test('runIssueVerification only invokes gh issue comment when --comment is explicit', async () => {
+    assert.equal(typeof verification.runIssueVerification, 'function');
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gwr-issue-verification-run-'));
+    await mkdir(path.join(tempRoot, 'samples'));
+    const calls = [];
+    const execFile = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === 'repo' && args[1] === 'view') {
+            return { stdout: 'GargantuaX/gemini-watermark-remover\n', stderr: '' };
+        }
+        if (args[0] === 'issue' && args[1] === 'view') {
+            return {
+                stdout: JSON.stringify({
+                    number: 120,
+                    title: 'Watermark remains',
+                    url: 'https://github.test/issues/120',
+                    body: 'local samples are supplied',
+                    state: 'OPEN'
+                }),
+                stderr: ''
+            };
+        }
+        if (args[0] === 'issue' && args[1] === 'comment') {
+            return { stdout: 'https://github.test/comment/1\n', stderr: '' };
+        }
+        throw new Error(`unexpected command: ${command} ${args.join(' ')}`);
+    };
+    const benchmarkRunner = async ({ outputPath }) => {
+        await writeFile(outputPath, `${JSON.stringify({
+            dataset: { mode: 'assumed-watermarked', contentSetSha256: 'content-hash' },
+            summary: { total: 1, passCount: 0, failCount: 1, excludedCount: 0, buckets: { 'residual-edge': 1 } },
+            metrics: {
+                watermarkDetectionRecall: { numerator: 1, denominator: 1, rate: 1 },
+                watermarkEndToEndPassRate: { numerator: 0, denominator: 1, rate: 0 }
+            }
+        }, null, 2)}\n`);
+    };
+
+    try {
+        const baseOptions = {
+            issue: 120,
+            repo: null,
+            sampleRoot: path.join(tempRoot, 'samples'),
+            outputDir: path.join(tempRoot, 'output'),
+            baseline: null,
+            comment: false
+        };
+        await verification.runIssueVerification(baseOptions, { execFile, benchmarkRunner, cwd: repoRoot });
+        assert.equal(calls.some(({ args }) => args[0] === 'issue' && args[1] === 'comment'), false);
+
+        await verification.runIssueVerification({ ...baseOptions, comment: true }, {
+            execFile,
+            benchmarkRunner,
+            cwd: repoRoot
+        });
+        assert.equal(calls.filter(({ args }) => args[0] === 'issue' && args[1] === 'comment').length, 1);
+    } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+});
+
+test('runIssueVerification safely resumes an interrupted release download', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gwr-issue-verification-resume-'));
+    const imageBytes = Buffer.from('release-image');
+    const digest = createHash('sha256').update(imageBytes).digest('hex');
+    const execFile = async (_command, args) => {
+        if (args[0] === 'issue' && args[1] === 'view') {
+            return {
+                stdout: JSON.stringify({
+                    number: 120,
+                    title: 'Interrupted download',
+                    url: 'https://github.test/issues/120',
+                    body: 'https://github.com/acme/samples/releases/tag/v1',
+                    state: 'OPEN'
+                }),
+                stderr: ''
+            };
+        }
+        if (args[0] === 'api') {
+            return {
+                stdout: JSON.stringify({
+                    id: 1,
+                    assets: [{ name: 'sample.png', digest: `sha256:${digest}` }]
+                }),
+                stderr: ''
+            };
+        }
+        if (args[0] === 'release' && args[1] === 'download') {
+            assert.ok(args.includes('--clobber'), 'resume must tolerate a file appearing after cache inspection');
+            const destination = args[args.indexOf('--dir') + 1];
+            await writeFile(path.join(destination, 'sample.png'), imageBytes);
+            return { stdout: '', stderr: '' };
+        }
+        throw new Error(`unexpected command: ${args.join(' ')}`);
+    };
+    const benchmarkRunner = async ({ outputPath }) => {
+        await writeFile(outputPath, `${JSON.stringify({
+            dataset: { mode: 'assumed-watermarked', contentSetSha256: digest },
+            summary: { total: 1, passCount: 1, failCount: 0, excludedCount: 0, buckets: { pass: 1 } },
+            metrics: {}
+        })}\n`);
+    };
+
+    try {
+        const result = await verification.runIssueVerification({
+            issue: 120,
+            repo: 'owner/project',
+            sampleRoot: null,
+            outputDir: tempRoot,
+            baseline: null,
+            comment: false
+        }, { execFile, benchmarkRunner, cwd: repoRoot });
+        assert.equal(result.source.verifiedAssetCount, 1);
+    } finally {
+        await rm(tempRoot, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary

- add `pnpm issue:verify -- --issue <number>` for repeatable GitHub issue sample verification
- reuse the authenticated `gh` keyring session, parse linked GitHub Releases, cache image assets, and verify available SHA-256 digests
- run the existing external sample benchmark and generate JSON, Markdown, CSV, and a reviewable issue-comment draft
- keep GitHub publication opt-in behind `--comment`; never close the issue automatically
- document the workflow and local-sample/baseline overrides

This automation branch is based directly on `origin/main` and is intentionally independent from the R192 algorithm change in #124.

## Validation

- `node --test tests/scripts/githubIssueVerification.test.js` — 7 passed
- `node --test --test-concurrency=1 tests/scripts/*.test.js` — 633 passed
- `node --check scripts/verify-github-issue.js`
- `node --check tests/scripts/githubIssueVerification.test.js`
- `git diff --check`
- real dry-run against #120 (without `--comment`): 14/14 Release image assets SHA-256 verified; benchmark recorded 1 pass / 13 fail on `origin/main`; `commentPublished=false`

Relates to #120.
