### PR TITLE
Add evidence-gated V2 medium rescue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - Safety gates are a final fallback. If a visible watermark is skipped, first ask whether the selected position/size/alpha candidate is wrong or incomplete.
 - Do not generalize from a single image when the user supplied a sample set. Cluster samples by size, anchor, background, and residual behavior, then make the smallest algorithm change supported by that cluster.
 - When residual artifacts remain after mathematically valid inverse alpha removal, do not assume stronger inpaint, preview-only priors, or subpixel sweeps are safe production fixes. First verify whether the real alpha edge profile / antialiasing model differs from the current template, and keep any visual cleanup evidence-gated.
+- Do not treat a restoration score measured only with the candidate's own selected alpha map and geometry as independent cleanliness or damage evidence. A wrong candidate can erase the pattern it scores against while leaving an obvious hole, shifted star, or larger residual outside that ROI. Use those self-consistent scores for candidate ranking only; promotion evidence should come from frozen cross-profile/decoy signals and blind visual review.
 
 ## Deployment Note
 

--- a/src/core/pipelineInitialSelection.js
+++ b/src/core/pipelineInitialSelection.js
@@ -6,7 +6,10 @@ import {
     createCandidateHypothesis,
     selectDiverseCandidateHypotheses
 } from './pipelineCandidatePool.js';
-import { computeRegionSpatialCorrelation } from './adaptiveDetector.js';
+import {
+    computeRegionSpatialCorrelation,
+    interpolateAlphaMap
+} from './adaptiveDetector.js';
 import { calculateNearBlackRatio } from './restorationMetrics.js';
 import { hasReliableStandardWatermarkSignal } from './watermarkPresence.js';
 
@@ -41,6 +44,115 @@ const REPEATED_TEMPLATE_CONTROL_SQUARES = [
     [[-1, 0], [0, -1], [-1, -1]],
     [[-2, 0], [0, -2], [-2, -2]]
 ];
+const CONFIRMED_V2_MEDIUM_IMAGE_WIDTH = 768;
+const CONFIRMED_V2_MEDIUM_IMAGE_HEIGHT = 1376;
+const CONFIRMED_V2_MEDIUM_LOGO_SIZE = 48;
+const CONFIRMED_V2_MEDIUM_MARGIN = 73;
+const CONFIRMED_V2_MEDIUM_MIN_RESCUE_SPATIAL = 0.4;
+const CONFIRMED_V2_MEDIUM_MIN_RESCUE_GRADIENT = 0.5;
+const CONFIRMED_V2_SMALL_PRIOR_MIN_SPATIAL = 0.3;
+
+// The Allenk V2 renderer and the trusted 768x1376 sample cluster agree on
+// 48px / 73px geometry. Keep it out of the generic catalog because structured
+// clean content at this size can still correlate with the V2 template.
+function isConfirmedV2SmallSelection(trial) {
+    return trial?.config?.logoSize === 36 &&
+        trial.config.marginRight === 96 &&
+        trial.config.marginBottom === 96 &&
+        Number(trial.originalSpatialScore) >=
+            CONFIRMED_V2_SMALL_PRIOR_MIN_SPATIAL &&
+        (
+            trial.config.alphaVariant === 'v2' ||
+            trial.provenance?.alphaVariant === 'v2'
+        );
+}
+
+function createConfirmedV2MediumRescueTrial({
+    originalImageData,
+    getAlphaMap,
+    fixedSelection,
+    automaticSelection
+}) {
+    if (
+        originalImageData?.width !== CONFIRMED_V2_MEDIUM_IMAGE_WIDTH ||
+        originalImageData?.height !== CONFIRMED_V2_MEDIUM_IMAGE_HEIGHT ||
+        typeof getAlphaMap !== 'function'
+    ) {
+        return null;
+    }
+
+    const fixedTrial = fixedSelection?.selectedTrial;
+    const automaticTrial = automaticSelection?.selectedTrial;
+    const hasV2SmallPrior =
+        isConfirmedV2SmallSelection(fixedTrial) ||
+        isConfirmedV2SmallSelection(automaticTrial);
+
+    const alpha36V2 = getAlphaMap('36-v2');
+    if (!alpha36V2 || alpha36V2.length !== 36 * 36) return null;
+
+    const alphaMap = interpolateAlphaMap(
+        alpha36V2,
+        36,
+        CONFIRMED_V2_MEDIUM_LOGO_SIZE
+    );
+    const config = {
+        logoSize: CONFIRMED_V2_MEDIUM_LOGO_SIZE,
+        marginRight: CONFIRMED_V2_MEDIUM_MARGIN,
+        marginBottom: CONFIRMED_V2_MEDIUM_MARGIN,
+        alphaVariant: 'v2'
+    };
+    const position = {
+        x: originalImageData.width - config.marginRight - config.logoSize,
+        y: originalImageData.height - config.marginBottom - config.logoSize,
+        width: config.logoSize,
+        height: config.logoSize
+    };
+    const trial = evaluateRestorationCandidate({
+        originalImageData,
+        alphaMap,
+        position,
+        source: 'standard+confirmed-v2-medium-rescue',
+        config,
+        baselineNearBlackRatio: calculateNearBlackRatio(
+            originalImageData,
+            position
+        ),
+        alphaGain: 1,
+        provenance: {
+            catalogVariant: true,
+            fixedVariant: true,
+            alphaVariant: 'v2',
+            catalogFamily: 'confirmed-v2-medium-rescue',
+            catalogEvidenceGate: 'medium',
+            confirmedV2MediumRescue: true,
+            rescueReason: hasV2SmallPrior
+                ? 'replace-confirmed-v2-small-geometry'
+                : 'recover-strong-unconfirmed-v2-medium'
+        },
+        includeImageData: false
+    });
+    if (!trial?.accepted) return null;
+
+    // A strong 36px V2 prior is independent geometry evidence. Do not require
+    // its 48px replacement to pass the initial texture-damage heuristic here:
+    // the top-N executor still repairs, scores, and ranks the completed output.
+    // The confirmed bottle case begins with a false texture hard-reject but
+    // finishes without a damage warning after the normal repair pipeline.
+    if (
+        !hasV2SmallPrior &&
+        (
+            Number(trial.originalSpatialScore) <
+                CONFIRMED_V2_MEDIUM_MIN_RESCUE_SPATIAL ||
+            Number(trial.originalGradientScore) <
+                CONFIRMED_V2_MEDIUM_MIN_RESCUE_GRADIENT ||
+            trial.damage?.safe !== true
+        )
+    ) {
+        return null;
+    }
+
+    return trial;
+}
 
 function isSafeAggressiveFallbackSelection(selection) {
     const trial = selection?.selectedTrial;
@@ -548,6 +660,13 @@ export function collectInitialWatermarkCandidates(input = {}) {
             allowAutomaticSearch: true,
             allowAggressiveStrongLocated: true
         });
+    const potentialV2MediumRescueTrial =
+        createConfirmedV2MediumRescueTrial({
+            originalImageData: input.originalImageData,
+            getAlphaMap: input.getAlphaMap,
+            fixedSelection,
+            automaticSelection
+        });
     const fixedPresenceWitness = findWatermarkPresenceWitness(
         fixedSelection,
         input.originalImageData
@@ -556,6 +675,17 @@ export function collectInitialWatermarkCandidates(input = {}) {
         automaticSelection,
         input.originalImageData
     );
+    const normalPresenceConfirmed = Boolean(
+        fixedPresenceWitness || automaticPresenceWitness
+    );
+    const confirmedV2MediumRescueTrial =
+        (
+            potentialV2MediumRescueTrial?.provenance?.rescueReason ===
+                'replace-confirmed-v2-small-geometry' ||
+            !normalPresenceConfirmed
+        )
+            ? potentialV2MediumRescueTrial
+            : null;
     const geometryLockWitness =
         findStrongLocalizedGeometryTrial(
             fixedSelection,
@@ -566,7 +696,7 @@ export function collectInitialWatermarkCandidates(input = {}) {
             input.originalImageData
         );
     const presenceConfirmed = Boolean(
-        fixedPresenceWitness || automaticPresenceWitness
+        normalPresenceConfirmed || confirmedV2MediumRescueTrial
     );
     const bestEffortSelections = presenceConfirmed
         ? []
@@ -686,6 +816,7 @@ export function collectInitialWatermarkCandidates(input = {}) {
                 fixedSelection?.selectedTrial,
                 ...(automaticSelection?.candidatePool ?? []),
                 automaticSelection?.selectedTrial,
+                confirmedV2MediumRescueTrial,
                 ...conservativeTrials
             ]
     ).filter((trial) => (
@@ -728,11 +859,22 @@ export function collectInitialWatermarkCandidates(input = {}) {
             : null,
         1003
     );
+    const confirmedV2MediumRescueHypothesis = createCandidateHypothesis(
+        keepNonRepeatedTrial(confirmedV2MediumRescueTrial) &&
+            isGeometryCompatibleWithLock(
+                confirmedV2MediumRescueTrial,
+                geometryLockWitness
+            )
+            ? confirmedV2MediumRescueTrial
+            : null,
+        1004
+    );
     const preferredHypotheses = [
         fixedSelectedHypothesis,
         automaticSelectedHypothesis,
         fixedPresenceHypothesis,
-        automaticPresenceHypothesis
+        automaticPresenceHypothesis,
+        confirmedV2MediumRescueHypothesis
     ].filter((hypothesis, index, values) => (
         hypothesis &&
         values.findIndex((candidate) => sameTrialIdentity(
@@ -756,6 +898,8 @@ export function collectInitialWatermarkCandidates(input = {}) {
                 ? 'discovered-alternative'
                 : hypothesis.trial?.provenance?.topNConservative === true
                 ? 'conservative-derived'
+                : hypothesis.trial?.provenance?.confirmedV2MediumRescue === true
+                    ? 'confirmed-rescue'
                 : sameTrialIdentity(hypothesis.trial, fixedSelection?.selectedTrial)
                     ? 'fixed-selected'
                     : sameTrialIdentity(hypothesis.trial, automaticSelection?.selectedTrial)

--- a/tests/core/pipelineInitialSelection.test.js
+++ b/tests/core/pipelineInitialSelection.test.js
@@ -5,6 +5,8 @@ import {
     collectInitialWatermarkCandidates,
     selectInitialWatermarkCandidate
 } from '../../src/core/pipelineInitialSelection.js';
+import { interpolateAlphaMap } from '../../src/core/adaptiveDetector.js';
+import { getEmbeddedAlphaMap } from '../../src/core/embeddedAlphaMaps.js';
 
 function createBaseInput(selectCandidate) {
     return {
@@ -13,6 +15,52 @@ function createBaseInput(selectCandidate) {
         position: { x: 20, y: 20, width: 48, height: 48 },
         alpha48: new Float32Array(48 * 48),
         alpha96: new Float32Array(96 * 96),
+        alphaGainCandidates: [1],
+        alphaPriorityGains: [1],
+        selectCandidate
+    };
+}
+
+function createFlatImageData(width, height, value = 96) {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let index = 0; index < width * height; index++) {
+        const offset = index * 4;
+        data[offset] = value;
+        data[offset + 1] = value;
+        data[offset + 2] = value;
+        data[offset + 3] = 255;
+    }
+    return { width, height, data };
+}
+
+function applyWhiteWatermark(imageData, alphaMap, position) {
+    for (let y = 0; y < position.height; y++) {
+        for (let x = 0; x < position.width; x++) {
+            const alpha = alphaMap[y * position.width + x];
+            const offset = (
+                (position.y + y) * imageData.width +
+                position.x + x
+            ) * 4;
+            for (let channel = 0; channel < 3; channel++) {
+                imageData.data[offset + channel] = Math.round(
+                    imageData.data[offset + channel] * (1 - alpha) +
+                    255 * alpha
+                );
+            }
+        }
+    }
+}
+
+function createV2MediumCollectionInput(imageData, selectCandidate) {
+    return {
+        originalImageData: imageData,
+        config: { logoSize: 48, marginRight: 96, marginBottom: 96 },
+        position: { x: 624, y: 1232, width: 48, height: 48 },
+        alpha48: getEmbeddedAlphaMap(48),
+        alpha96: getEmbeddedAlphaMap(96),
+        getAlphaMap: (key) => key === '36-v2'
+            ? getEmbeddedAlphaMap('36-v2')
+            : null,
         alphaGainCandidates: [1],
         alphaPriorityGains: [1],
         selectCandidate
@@ -976,4 +1024,117 @@ test('collectInitialWatermarkCandidates should retain a localized direct-match p
         hypothesis.trial?.position?.width === 48 &&
         hypothesis.trial?.alphaGain <= 0.25
     )));
+});
+
+test('collectInitialWatermarkCandidates should rescue a strong exact 768x1376 V2 medium watermark when normal selection skips', () => {
+    const imageData = createFlatImageData(768, 1376, 72);
+    const alpha36V2 = getEmbeddedAlphaMap('36-v2');
+    const alpha48V2 = interpolateAlphaMap(alpha36V2, 36, 48);
+    const position = {
+        x: 768 - 73 - 48,
+        y: 1376 - 73 - 48,
+        width: 48,
+        height: 48
+    };
+    applyWhiteWatermark(imageData, alpha48V2, position);
+
+    const result = collectInitialWatermarkCandidates(
+        createV2MediumCollectionInput(imageData, () => ({
+            selectedTrial: null,
+            candidatePool: [],
+            source: 'skipped',
+            decisionTier: 'insufficient'
+        }))
+    );
+
+    const rescue = result.hypotheses.find((hypothesis) => (
+        hypothesis.trial?.provenance?.confirmedV2MediumRescue === true
+    ));
+    assert.equal(result.presenceConfirmed, true);
+    assert.ok(rescue, 'expected exact V2 medium rescue hypothesis');
+    assert.deepEqual(rescue.trial.config, {
+        logoSize: 48,
+        marginRight: 73,
+        marginBottom: 73,
+        alphaVariant: 'v2'
+    });
+    assert.equal(rescue.trial.alphaGain, 1);
+});
+
+test('collectInitialWatermarkCandidates should not rescue an exact 768x1376 image without V2 evidence', () => {
+    const imageData = createFlatImageData(768, 1376, 72);
+    const result = collectInitialWatermarkCandidates(
+        createV2MediumCollectionInput(imageData, () => ({
+            selectedTrial: null,
+            candidatePool: [],
+            source: 'skipped',
+            decisionTier: 'insufficient'
+        }))
+    );
+
+    assert.equal(result.presenceConfirmed, false);
+    assert.equal(result.hypotheses.length, 0);
+});
+
+test('collectInitialWatermarkCandidates should only replace a sufficiently strong 36px V2 prior with the medium rescue', () => {
+    const imageData = createFlatImageData(768, 1376, 72);
+    const alpha36V2 = getEmbeddedAlphaMap('36-v2');
+    const alpha48V2 = interpolateAlphaMap(alpha36V2, 36, 48);
+    applyWhiteWatermark(imageData, alpha48V2, {
+        x: 768 - 73 - 48,
+        y: 1376 - 73 - 48,
+        width: 48,
+        height: 48
+    });
+    const prior = {
+        source: 'standard+catalog+validated',
+        config: {
+            logoSize: 36,
+            marginRight: 96,
+            marginBottom: 96,
+            alphaVariant: 'v2'
+        },
+        position: {
+            x: 768 - 96 - 36,
+            y: 1376 - 96 - 36,
+            width: 36,
+            height: 36
+        },
+        alphaMap: alpha36V2,
+        alphaGain: 1,
+        accepted: true,
+        evaluation: { eligible: true },
+        originalSpatialScore: 0,
+        originalGradientScore: 0.19,
+        processedSpatialScore: 0.01,
+        processedGradientScore: 0.12,
+        damage: { safe: true },
+        rankingKey: [2, -2, 0, 0.12, 1, 0],
+        provenance: {
+            catalogVariant: true,
+            alphaVariant: 'v2',
+            catalogFamily: 'gemini-v2-small',
+            catalogEvidenceGate: 'medium'
+        }
+    };
+
+    for (const [originalSpatialScore, expectedRescue] of [
+        [0.299, false],
+        [0.3, true]
+    ]) {
+        const selectedPrior = { ...prior, originalSpatialScore };
+        const result = collectInitialWatermarkCandidates(
+            createV2MediumCollectionInput(imageData, () => ({
+                selectedTrial: selectedPrior,
+                candidatePool: [selectedPrior],
+                source: selectedPrior.source,
+                decisionTier: 'validated-match'
+            }))
+        );
+
+        assert.equal(result.presenceConfirmed, true);
+        assert.equal(result.hypotheses.some((hypothesis) => (
+            hypothesis.trial?.provenance?.confirmedV2MediumRescue === true
+        )), expectedRescue);
+    }
 });


### PR DESCRIPTION
## Summary

- add an evidence-gated rescue path for medium-confidence V2 watermark candidates
- keep the rescue constrained by independent source evidence and existing safety checks
- add focused regression coverage for admission and rejection cases

## Why

This commit was previously bundled into #124. Splitting it out keeps the V2 medium-rescue policy independently reviewable from the larger exact-watermark and R192 work.

## Stack

This is the first PR in the #124 split stack:

1. this PR -> `main`
2. exact watermark rescue -> this branch
3. #124 R192 handling and alpha-profile diagnostics -> exact watermark rescue branch

## Validation

- the original branch CI passed before the split
- this PR points at the unchanged, previously tested commit `707436c`
- no commit history was rewritten during the split

Relates to #120.
