### PR TITLE
Fix small video watermark processing

### DIFF
--- a/scripts/export-video-backend-variant.js
+++ b/scripts/export-video-backend-variant.js
@@ -140,6 +140,7 @@ async function blobUrlToBuffer(page) {
 
 async function collectVideoExportControls(page) {
     return await page.evaluate(() => ({
+        adaptiveAlpha: Boolean(document.getElementById('adaptiveAlpha')?.checked),
         denoiseBackend: document.getElementById('denoiseBackend')?.value || '',
         edgeDenoiseStrength: Number(document.getElementById('edgeDenoiseStrength')?.value),
         videoBitrateMbps: Number(document.getElementById('videoBitrateMbps')?.value),
@@ -258,6 +259,9 @@ export async function exportVideoBackendVariant({
                 }, Math.max(0.5, Math.min(1.5, alphaLocalBodyScale)));
             }
             if (adaptiveAlpha) {
+                await page.evaluate(() => {
+                    window.__gwrVideoOverrideAdaptiveAlpha = true;
+                });
                 await setCheckboxValue(page, '#adaptiveAlpha', true);
             }
             if (Number.isFinite(edgeDenoiseStrength)) {

--- a/src/sdk/video.js
+++ b/src/sdk/video.js
@@ -182,6 +182,7 @@ async function readDownloadBufferFromPage(page) {
 
 async function collectVideoControls(page) {
     return page.evaluate(() => ({
+        adaptiveAlpha: Boolean(document.getElementById('adaptiveAlpha')?.checked),
         denoiseBackend: document.getElementById('denoiseBackend')?.value || '',
         edgeDenoiseStrength: Number(document.getElementById('edgeDenoiseStrength')?.value),
         residualCleanupStrength: Number(document.getElementById('residualCleanup')?.value),
@@ -224,6 +225,9 @@ async function processVideoWithPreviewPage(inputPath, options = {}) {
             await setControlValue(page, '#denoiseBackend', denoiseBackend);
 
             if (adaptiveAlpha) {
+                await page.evaluate(() => {
+                    window.__gwrVideoOverrideAdaptiveAlpha = true;
+                });
                 await setCheckboxValue(page, '#adaptiveAlpha', true);
             }
             if (allowLowConfidence) {

--- a/src/video-app.js
+++ b/src/video-app.js
@@ -18,7 +18,10 @@ import {
     getRelocatedReviewPresetConfig
 } from './video/videoPresetPolicy.js';
 import { resolveAllenkFdncnnRuntimeProfile } from './video/videoDenoiseRuntimePolicy.js';
-import { applyVideoBitrateDebugOverride } from './video/videoDebugControlOverrides.js';
+import {
+    applyVideoAdaptiveAlphaDebugOverride,
+    applyVideoBitrateDebugOverride
+} from './video/videoDebugControlOverrides.js';
 import {
     consumeDebugFileHandoff,
     getDebugFileKind,
@@ -740,6 +743,10 @@ function applyAutomaticPreset(detection = state.detection, metadata = state.meta
 }
 
 function applyDebugControlOverrides() {
+    applyVideoAdaptiveAlphaDebugOverride({
+        windowObject: window,
+        adaptiveAlphaInput: els.adaptiveAlpha
+    });
     if (typeof window.__gwrVideoOverrideDenoiseBackend === 'string') {
         if (els.denoiseBackend.value !== window.__gwrVideoOverrideDenoiseBackend) {
             els.denoiseBackend.value = window.__gwrVideoOverrideDenoiseBackend;

--- a/src/video/videoDebugControlOverrides.js
+++ b/src/video/videoDebugControlOverrides.js
@@ -1,3 +1,14 @@
+export function applyVideoAdaptiveAlphaDebugOverride({
+    windowObject = globalThis,
+    adaptiveAlphaInput
+} = {}) {
+    const adaptiveAlpha = windowObject?.__gwrVideoOverrideAdaptiveAlpha;
+    if (typeof adaptiveAlpha !== 'boolean' || !adaptiveAlphaInput) return false;
+
+    adaptiveAlphaInput.checked = adaptiveAlpha;
+    return true;
+}
+
 export function applyVideoBitrateDebugOverride({
     windowObject = globalThis,
     videoBitrateInput,

--- a/src/video/videoWatermarkDetector.js
+++ b/src/video/videoWatermarkDetector.js
@@ -18,6 +18,7 @@ const VIDEO_INSET_ALPHA_EDGE_BOOST = 0.035;
 const ALPHA_REFINEMENT_ROUNDS = 5;
 const LOGO_VALUE = 255;
 const AUTO_ALPHA_SHAPE_MIN_SIZE = 40;
+const VIDEO_V1_ALPHA_MAX_SIZE = AUTO_ALPHA_SHAPE_MIN_SIZE - 1;
 const AUTO_ALPHA_SHAPE_MIN_IMPROVEMENT = 0.04;
 const AUTO_ALPHA_SHAPE_MIN_RELATIVE_IMPROVEMENT = 0.08;
 const AUTO_ALPHA_SHAPE_MAX_EDGE_BOOST = 0.12;
@@ -97,7 +98,10 @@ export function resolveVideoAlphaEdgeBoost(candidate = null) {
 }
 
 function getVideoAlphaMap(size, options = {}) {
-    const profile = normalizeVideoAlphaProfile(options.profile ?? options.alphaProfile);
+    const requestedProfile = options.profile ?? options.alphaProfile;
+    const profile = requestedProfile === undefined || requestedProfile === null || requestedProfile === ''
+        ? (size <= VIDEO_V1_ALPHA_MAX_SIZE ? 48 : VIDEO_ALPHA_PROFILE)
+        : normalizeVideoAlphaProfile(requestedProfile);
     const alphaSource =
         getEmbeddedAlphaMap(profile) ||
         getEmbeddedAlphaMap(VIDEO_ALPHA_PROFILE) ||

--- a/tests/video/videoDebugControlOverrides.test.js
+++ b/tests/video/videoDebugControlOverrides.test.js
@@ -4,6 +4,22 @@ import assert from 'node:assert/strict';
 import {
     applyVideoBitrateDebugOverride
 } from '../../src/video/videoDebugControlOverrides.js';
+import * as videoDebugControlOverrides from '../../src/video/videoDebugControlOverrides.js';
+
+test('applyVideoAdaptiveAlphaDebugOverride should restore an explicit SDK choice after automatic presets', () => {
+    assert.equal(typeof videoDebugControlOverrides.applyVideoAdaptiveAlphaDebugOverride, 'function');
+
+    const checkbox = { checked: false };
+    const applied = videoDebugControlOverrides.applyVideoAdaptiveAlphaDebugOverride({
+        windowObject: {
+            __gwrVideoOverrideAdaptiveAlpha: true
+        },
+        adaptiveAlphaInput: checkbox
+    });
+
+    assert.equal(applied, true);
+    assert.equal(checkbox.checked, true);
+});
 
 test('applyVideoBitrateDebugOverride should write bitrate overrides after automatic presets', () => {
     const input = { value: '12' };

--- a/tests/video/videoWatermarkDetector.test.js
+++ b/tests/video/videoWatermarkDetector.test.js
@@ -122,6 +122,40 @@ test('getVideoAlphaMap should support experimental embedded alpha profile select
     assert.ok(legacyMax > defaultMax, { defaultMax, legacyMax });
 });
 
+test('detectVideoWatermarkFromFrames should use the V1 alpha family for projected 32px video marks', () => {
+    const width = 848;
+    const height = 478;
+    const target = resolveVideoWatermarkCandidates(width, height)
+        .find((candidate) => candidate.id === 'veo-1080p-inset');
+    const v1Alpha = getVideoAlphaMap(target.size, {
+        candidate: target,
+        alphaProfile: 48
+    });
+    const frames = [];
+
+    for (let i = 0; i < 4; i++) {
+        const imageData = createPatternImageData(width, height);
+        applyWhiteWatermark(imageData, v1Alpha, {
+            x: target.x,
+            y: target.y,
+            width: target.size,
+            height: target.size
+        });
+        frames.push({ timestamp: i / 24, imageData });
+    }
+
+    const result = detectVideoWatermarkFromFrames({
+        frames,
+        width,
+        height,
+        candidates: [target],
+        minConfidence: 0.02
+    });
+
+    assert.equal(result.candidate.id, target.id);
+    assert.deepEqual(result.alphaMap, v1Alpha);
+});
+
 test('detectVideoWatermarkFromFrames should auto-select a legacy alpha shape for relocated portrait frames', () => {
     const width = 720;
     const height = 1280;


### PR DESCRIPTION
## What changed

- Default projected video watermarks smaller than 40px to the V1 alpha family. Sizes at or above 40px keep the existing multi-shape selection path.
- Preserve an explicit `adaptiveAlpha: true` choice from the SDK and backend-variant script after the video page reapplies its automatic preset.
- Add regressions for the 848x478 / 32px projected watermark reported in #119 and for the SDK control override.

## Root cause

The #119 sample resolves to the `veo-1080p-inset` candidate at 32x32. That size is below the detector's automatic alpha-shape selection threshold, so it was permanently using the large V2 default even when the smaller V1 template fit the source better. Separately, an explicit SDK adaptive-alpha option was set before export but then cleared when `runExport()` reapplied the automatic preset.

## Validation

- `node --test tests/video/videoDebugControlOverrides.test.js tests/video/videoExportCleanupOptions.test.js tests/sdk/videoPreviewPage.test.js tests/video/videoWatermarkDetector.test.js` — 26/26 passed
- `pnpm build` — passed
- `pnpm verify:video-regression-samples` — 5/5 real-video fixtures passed
- #119 original sample, website preset without an explicit alpha profile: fixed-anchor confidence `0.3795 -> 0.0366`, a 90.4% reduction and a `pass` verdict

Addresses #119. Related investigation: #114 and #121.
