### PR TITLE
Fix video frame estimates and timeout scope

### DIFF
--- a/src/sdk/video.js
+++ b/src/sdk/video.js
@@ -3,9 +3,12 @@ import { createReadStream } from 'node:fs';
 import { createServer } from 'node:http';
 import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import {
+    DEFAULT_VIDEO_TIMEOUT_MS,
+    configureVideoPageTimeouts
+} from './videoProgress.js';
 
 const DEFAULT_VIDEO_DENOISE_BACKEND = 'allenk-fdncnn-browser-spike';
-const DEFAULT_VIDEO_TIMEOUT_MS = 6 * 60 * 1000;
 
 function normalizeBufferLike(value) {
     if (Buffer.isBuffer(value)) return value;
@@ -216,7 +219,7 @@ async function processVideoWithPreviewPage(inputPath, options = {}) {
     try {
         return await withLocalVideoPreviewPage(pagePath, async (pageUrl) => {
             const page = await browser.newPage();
-            page.setDefaultTimeout(timeoutMs);
+            configureVideoPageTimeouts(page);
             await page.goto(pageUrl);
             await page.locator('#fileInput').setInputFiles(inputPath);
             await page.evaluate((value) => {

--- a/src/sdk/videoProgress.js
+++ b/src/sdk/videoProgress.js
@@ -1,0 +1,13 @@
+const DEFAULT_VIDEO_TIMEOUT_MS = 6 * 60 * 1000;
+const DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS = 30_000;
+
+function configureVideoPageTimeouts(page) {
+    page.setDefaultTimeout(DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS);
+    page.setDefaultNavigationTimeout(DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS);
+}
+
+export {
+    DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS,
+    DEFAULT_VIDEO_TIMEOUT_MS,
+    configureVideoPageTimeouts
+};

--- a/src/video/videoExport.js
+++ b/src/video/videoExport.js
@@ -30,6 +30,7 @@ import {
     normalizeVideoCleanupOptions
 } from './videoCleanupBackends.js';
 import { resolveAllenkFdncnnRuntimeProfile } from './videoDenoiseRuntimePolicy.js';
+import { resolveVideoMetadata } from './videoMetadata.js';
 
 const DEFAULT_SAMPLE_COUNT = 12;
 const DEFAULT_ALPHA_GAIN = 1;
@@ -93,35 +94,6 @@ async function getVideoContext(file) {
         throw new Error('文件中没有可处理的视频轨');
     }
     return { input, videoTrack };
-}
-
-async function resolveVideoMetadata(input, videoTrack) {
-    const [width, height, firstTimestamp, codec, durationFromMetadata, packetStats] = await Promise.all([
-        videoTrack.getDisplayWidth(),
-        videoTrack.getDisplayHeight(),
-        videoTrack.getFirstTimestamp().catch(() => 0),
-        videoTrack.getCodec().catch(() => null),
-        input.getDurationFromMetadata([videoTrack], { skipLiveWait: true }).catch(() => null),
-        videoTrack.computePacketStats(90, { skipLiveWait: true }).catch(() => null)
-    ]);
-
-    const duration = Number.isFinite(durationFromMetadata) && durationFromMetadata > 0
-        ? durationFromMetadata
-        : await videoTrack.computeDuration({ skipLiveWait: true }).catch(() => null);
-    const frameRate = packetStats?.averagePacketRate && Number.isFinite(packetStats.averagePacketRate)
-        ? packetStats.averagePacketRate
-        : 30;
-
-    return {
-        width,
-        height,
-        firstTimestamp: Number.isFinite(firstTimestamp) ? firstTimestamp : 0,
-        duration: Number.isFinite(duration) ? duration : null,
-        codec,
-        frameRate,
-        frameCountEstimate: packetStats?.packetCount || (duration ? Math.round(duration * frameRate) : null),
-        averageBitrate: packetStats?.averageBitrate || null
-    };
 }
 
 function getSampleTargetTimestamps({ firstTimestamp, duration, sampleCount }) {

--- a/src/video/videoMetadata.js
+++ b/src/video/videoMetadata.js
@@ -1,0 +1,35 @@
+async function resolveVideoMetadata(input, videoTrack) {
+    const [width, height, firstTimestamp, codec, durationFromMetadata, packetStats] = await Promise.all([
+        videoTrack.getDisplayWidth(),
+        videoTrack.getDisplayHeight(),
+        videoTrack.getFirstTimestamp().catch(() => 0),
+        videoTrack.getCodec().catch(() => null),
+        input.getDurationFromMetadata([videoTrack], { skipLiveWait: true }).catch(() => null),
+        videoTrack.computePacketStats(90, { skipLiveWait: true }).catch(() => null)
+    ]);
+
+    const duration = Number.isFinite(durationFromMetadata) && durationFromMetadata > 0
+        ? durationFromMetadata
+        : await videoTrack.computeDuration({ skipLiveWait: true }).catch(() => null);
+    const sampledFrameRate = Number.isFinite(packetStats?.averagePacketRate)
+        && packetStats.averagePacketRate > 0
+        ? packetStats.averagePacketRate
+        : null;
+    const frameRate = sampledFrameRate || 30;
+    const frameCountEstimate = Number.isFinite(duration) && duration > 0 && sampledFrameRate
+        ? Math.max(1, Math.round(duration * sampledFrameRate))
+        : null;
+
+    return {
+        width,
+        height,
+        firstTimestamp: Number.isFinite(firstTimestamp) ? firstTimestamp : 0,
+        duration: Number.isFinite(duration) ? duration : null,
+        codec,
+        frameRate,
+        frameCountEstimate,
+        averageBitrate: packetStats?.averageBitrate || null
+    };
+}
+
+export { resolveVideoMetadata };

--- a/tests/sdk/videoProgress.test.js
+++ b/tests/sdk/videoProgress.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS,
+    configureVideoPageTimeouts
+} from '../../src/sdk/videoProgress.js';
+
+test('page setup timeouts remain independent from export completion timeout', () => {
+    const calls = [];
+    const page = {
+        setDefaultTimeout(value) {
+            calls.push(['action', value]);
+        },
+        setDefaultNavigationTimeout(value) {
+            calls.push(['navigation', value]);
+        }
+    };
+
+    configureVideoPageTimeouts(page);
+
+    assert.equal(DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS, 30_000);
+    assert.deepEqual(calls, [
+        ['action', DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS],
+        ['navigation', DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS]
+    ]);
+});

--- a/tests/video/videoMetadata.test.js
+++ b/tests/video/videoMetadata.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveVideoMetadata } from '../../src/video/videoMetadata.js';
+
+function createVideoTrack(packetStats, duration = 10) {
+    return {
+        getDisplayWidth: async () => 1920,
+        getDisplayHeight: async () => 1080,
+        getFirstTimestamp: async () => 0,
+        getCodec: async () => 'avc1.640028',
+        computePacketStats: async () => packetStats,
+        computeDuration: async () => duration
+    };
+}
+
+function createInput(duration = 10) {
+    return {
+        getDurationFromMetadata: async () => duration
+    };
+}
+
+test('resolveVideoMetadata estimates total frames from duration and sampled packet rate', async () => {
+    const metadata = await resolveVideoMetadata(
+        createInput(10),
+        createVideoTrack({
+            packetCount: 90,
+            averagePacketRate: 24,
+            averageBitrate: 8_000_000
+        })
+    );
+
+    assert.equal(metadata.frameRate, 24);
+    assert.equal(metadata.frameCountEstimate, 240);
+});
+
+test('resolveVideoMetadata does not treat the sampled packet count as a total without a sampled rate', async () => {
+    const metadata = await resolveVideoMetadata(
+        createInput(10),
+        createVideoTrack({
+            packetCount: 90,
+            averagePacketRate: null,
+            averageBitrate: 8_000_000
+        })
+    );
+
+    assert.equal(metadata.frameRate, 30);
+    assert.equal(metadata.frameCountEstimate, null);
+});


### PR DESCRIPTION
## Summary

- estimate total video frames from duration × sampled packet rate instead of treating the 90-packet metadata sample as the full video
- keep Playwright page action/navigation setup timeouts fixed at 30 seconds
- leave `--video-timeout-ms` scoped to the long-running video completion wait
- add focused regression tests for both defects

## Root cause

`computePacketStats(90)` returns a bounded sample, but its `packetCount` was used as the total frame count. This made longer clips report progress such as `240 / 90`.

The same user-configurable video timeout was also installed as Playwright's global page timeout, so small processing timeouts could fail during `page.goto` before video processing started.

## Impact

Progress estimates now reflect the clip duration and sampled frame rate. Video completion timeout tuning no longer changes page navigation or control setup timeouts.

## Validation

- `pnpm test`: 1688 tests, 1656 passed, 32 skipped, 0 failed
- `pnpm build`
- real MP4 metadata probe: 6.333 s × 30 fps = 190 estimated frames while the bounded sample remained 90 packets
- CLI probe with `--video-timeout-ms 100`: reached the completion wait and timed out at `page.waitForFunction`, not `page.goto`

## Attribution

This is a focused extraction of the two reviewed fixes from #110 without bringing in the broader batch-processing changes. Thanks to @shantz1 for the original report and implementation direction.
