### PR TITLE
Improve video CLI progress and bitrate controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ node bin/gwr.mjs remove <input> --output <file>
 gwr remove <input> [--output <file> | --out-dir <dir>] [--overwrite] [--json]
 ```
 
+Video exports default to the repository's calibrated 12 Mbps AVC profile. For a
+quality-sensitive source, request a higher encoder target explicitly:
+
+```bash
+gwr remove input.mp4 --output clean.mp4 --video-bitrate-mbps 20
+```
+
+The CLI reports video frame progress on stderr. `--video-timeout-ms` is an
+inactivity timeout: an export may run longer than that value as long as frames
+continue to advance.
+
 If you do not have `gwr` installed globally, use:
 
 ```bash

--- a/examples/sdk-consumer-ts/consumer.ts
+++ b/examples/sdk-consumer-ts/consumer.ts
@@ -6,7 +6,9 @@ import {
 } from '@pilio/gemini-watermark-remover';
 import {
     inferMimeTypeFromPath,
-    type NodeBufferRemovalOptions
+    type NodeBufferRemovalOptions,
+    type VideoFileRemovalOptions,
+    type VideoProcessingProgress
 } from '@pilio/gemini-watermark-remover/node';
 import { createBrowserRuntimeProcessor } from '@pilio/gemini-watermark-remover/runtime-browser';
 import { createUserscriptRuntimeProcessor } from '@pilio/gemini-watermark-remover/runtime-userscript';
@@ -66,12 +68,22 @@ const options: NodeBufferRemovalOptions = {
         return Buffer.from([]);
     }
 };
+const videoOptions: VideoFileRemovalOptions = {
+    videoBitrate: 20_000_000,
+    onProgress(progress: VideoProcessingProgress) {
+        const ratio: number | null = progress.progress;
+        const frames: number | null = progress.processedFrames;
+        void ratio;
+        void frames;
+    }
+};
 
 void enginePromise;
 void result.meta;
 void processingContract;
 void manualMeta;
 void options;
+void videoOptions;
 void browserRuntime.processWatermarkBlob;
 void userscriptRuntime.processWatermarkBlob;
 void userscriptRuntime.initialize;

--- a/src/cli/gwrCli.js
+++ b/src/cli/gwrCli.js
@@ -2,7 +2,7 @@ import { runRemoveCommand } from './gwrRemoveCommand.js';
 
 export async function main(argv, io) {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
-    io.stdout.write('Usage: gwr remove <input> [--output <file> | --out-dir <dir>] [--overwrite] [--json] [--video-page <url-or-file>]\n');
+    io.stdout.write('Usage: gwr remove <input> [--output <file> | --out-dir <dir>] [--overwrite] [--json] [--video-page <url-or-file>] [--video-timeout-ms <ms>] [--video-bitrate-mbps <Mbps>]\n');
     return 0;
   }
 

--- a/src/cli/gwrRemoveCommand.js
+++ b/src/cli/gwrRemoveCommand.js
@@ -10,9 +10,9 @@ import {
 } from '../sdk/node.js';
 
 const REMOVE_USAGE =
-  'Usage: gwr remove <input> [--output <file> | --out-dir <dir>] [--overwrite] [--json] [--video-page <url-or-file>]';
+  'Usage: gwr remove <input> [--output <file> | --out-dir <dir>] [--overwrite] [--json] [--video-page <url-or-file>] [--video-timeout-ms <ms>] [--video-bitrate-mbps <Mbps>]';
 
-export async function runRemoveCommand(argv, io) {
+export async function runRemoveCommand(argv, io, dependencies = {}) {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
     io.stdout.write(`${REMOVE_USAGE}\n`);
     return 0;
@@ -24,7 +24,12 @@ export async function runRemoveCommand(argv, io) {
     return 2;
   }
 
-  const commandOptions = { ...options, imageCodecPromise: null };
+  const commandOptions = {
+    ...options,
+    imageCodecPromise: null,
+    onVideoProgress: createVideoProgressReporter(io.stderr),
+    removeVideoFile: dependencies.removeVideoWatermarkFromFile || removeVideoWatermarkFromFile
+  };
   const inputStats = await stat(commandOptions.input).catch(() => null);
   if (!inputStats) {
     io.stderr.write(`Input not found: ${commandOptions.input}\n`);
@@ -66,6 +71,7 @@ function parseRemoveArgs(argv) {
     videoPage: null,
     videoDenoiseBackend: null,
     videoTimeoutMs: null,
+    videoBitrateMbps: null,
     allowLowConfidence: false
   };
 
@@ -142,6 +148,14 @@ function parseRemoveArgs(argv) {
       continue;
     }
 
+    if (token === '--video-bitrate-mbps') {
+      const parsed = parseOptionValue(argv, index, '--video-bitrate-mbps');
+      if (!parsed.ok) return parsed;
+      options.videoBitrateMbps = Number(parsed.value);
+      index = parsed.index;
+      continue;
+    }
+
     if (token === '--overwrite') {
       options.overwrite = true;
       continue;
@@ -180,6 +194,10 @@ function parseRemoveArgs(argv) {
     return { ok: false, error: '--video-timeout-ms must be a positive number.' };
   }
 
+  if (options.videoBitrateMbps !== null && (!Number.isFinite(options.videoBitrateMbps) || options.videoBitrateMbps <= 0)) {
+    return { ok: false, error: '--video-bitrate-mbps must be a positive number.' };
+  }
+
   return options;
 }
 
@@ -202,6 +220,30 @@ function parseOptionValue(argv, optionIndex, optionName) {
   }
 
   return { ok: true, value: nextToken, index: optionIndex + 1 };
+}
+
+function createVideoProgressReporter(stderr) {
+  let lastPercent = -1;
+  let lastPhase = null;
+
+  return (progress = {}) => {
+    const percent = Number.isFinite(progress.progress)
+      ? Math.max(0, Math.min(100, Math.round(progress.progress * 100)))
+      : null;
+    const phaseChanged = progress.phase && progress.phase !== lastPhase;
+    const percentChanged = percent !== null && (percent === 100 || percent >= lastPercent + 5);
+    if (!phaseChanged && !percentChanged) return;
+
+    const frameLabel = Number.isFinite(progress.processedFrames)
+      ? ` ${progress.processedFrames}${Number.isFinite(progress.frameEstimate) ? `/${progress.frameEstimate}` : ''} frames`
+      : '';
+    const inferenceLabel = Number.isFinite(progress.aiDenoiseFrames) || Number.isFinite(progress.aiReuseFrames)
+      ? ` (AI ${progress.aiDenoiseFrames || 0}, reused ${progress.aiReuseFrames || 0})`
+      : '';
+    stderr.write(`[video] ${percent ?? '?'}%${frameLabel}${inferenceLabel}\n`);
+    if (percent !== null) lastPercent = percent;
+    lastPhase = progress.phase || lastPhase;
+  };
 }
 
 async function resolveCodecOptions(options) {
@@ -337,7 +379,7 @@ async function processOneFile(inputPath, outputPath, options) {
 
   await mkdir(path.dirname(outputPath), { recursive: true });
   if (isVideoPath(inputPath) || isVideoPath(outputPath)) {
-    const result = await removeVideoWatermarkFromFile(inputPath, {
+    const result = await options.removeVideoFile(inputPath, {
       outputPath,
       mimeType: inferVideoMimeTypeFromPath(outputPath || inputPath),
       pagePath: options.videoPage || undefined,
@@ -345,6 +387,10 @@ async function processOneFile(inputPath, outputPath, options) {
       timeoutMs: Number.isFinite(options.videoTimeoutMs) && options.videoTimeoutMs > 0
         ? options.videoTimeoutMs
         : undefined,
+      videoBitrate: Number.isFinite(options.videoBitrateMbps) && options.videoBitrateMbps > 0
+        ? options.videoBitrateMbps * 1_000_000
+        : undefined,
+      onProgress: options.onVideoProgress,
       allowLowConfidence: options.allowLowConfidence
     });
 
@@ -383,3 +429,5 @@ async function getImageCodec(options) {
   }
   return options.imageCodecPromise;
 }
+
+export { parseRemoveArgs };

--- a/src/sdk/node.d.ts
+++ b/src/sdk/node.d.ts
@@ -4,6 +4,7 @@ export type {
     VideoBufferRemovalResult,
     VideoFileRemovalOptions,
     VideoFileRemovalResult,
+    VideoProcessingProgress,
     VideoRemovalMeta
 } from './video.js';
 

--- a/src/sdk/video.d.ts
+++ b/src/sdk/video.d.ts
@@ -7,6 +7,19 @@ export interface VideoRemovalMeta {
     [key: string]: unknown;
 }
 
+export interface VideoProcessingProgress {
+    tone: string;
+    status: string;
+    progressText: string;
+    progress: number | null;
+    phase: string | null;
+    processedFrames: number | null;
+    frameEstimate: number | null;
+    aiDenoiseFrames: number | null;
+    aiReuseFrames: number | null;
+    elapsedMs: number;
+}
+
 export interface VideoFileProcessorContext {
     outputPath?: string | null;
     mimeType: string;
@@ -21,6 +34,7 @@ export interface VideoFileProcessorContext {
     adaptiveAlpha?: boolean;
     alphaGain?: number;
     alphaProfile?: string;
+    onProgress?: (progress: VideoProcessingProgress) => void;
 }
 
 export interface VideoBufferProcessorContext extends Omit<VideoFileProcessorContext, 'filePath'> {
@@ -45,6 +59,7 @@ export interface VideoFileRemovalOptions {
     adaptiveAlpha?: boolean;
     alphaGain?: number;
     alphaProfile?: string;
+    onProgress?: (progress: VideoProcessingProgress) => void;
     processVideoFile?: (
         inputPath: string,
         context: VideoFileProcessorContext

--- a/src/sdk/video.js
+++ b/src/sdk/video.js
@@ -5,7 +5,8 @@ import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import {
     DEFAULT_VIDEO_TIMEOUT_MS,
-    configureVideoPageTimeouts
+    configureVideoPageTimeouts,
+    waitForVideoProcessing
 } from './videoProgress.js';
 
 const DEFAULT_VIDEO_DENOISE_BACKEND = 'allenk-fdncnn-browser-spike';
@@ -205,7 +206,8 @@ async function processVideoWithPreviewPage(inputPath, options = {}) {
         videoBitrate,
         adaptiveAlpha = false,
         alphaGain,
-        alphaProfile
+        alphaProfile,
+        onProgress
     } = options;
 
     if (!isHttpUrl(pagePath)) {
@@ -269,13 +271,10 @@ async function processVideoWithPreviewPage(inputPath, options = {}) {
             }
 
             await page.locator('#processBtn').click();
-            await page.waitForFunction(() => {
-                const status = document.getElementById('status');
-                return status?.dataset?.tone === 'success' || status?.dataset?.tone === 'error';
-            }, null, { timeout: timeoutMs });
-
-            const status = await page.locator('#status').textContent();
-            const tone = await page.locator('#status').getAttribute('data-tone');
+            const { status, tone } = await waitForVideoProcessing(page, {
+                timeoutMs,
+                onProgress
+            });
             if (tone !== 'success') {
                 throw new Error(status || 'Video export failed');
             }

--- a/src/sdk/videoProgress.js
+++ b/src/sdk/videoProgress.js
@@ -1,13 +1,108 @@
 const DEFAULT_VIDEO_TIMEOUT_MS = 6 * 60 * 1000;
+const DEFAULT_VIDEO_PROGRESS_POLL_INTERVAL_MS = 1000;
 const DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS = 30_000;
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readVideoProgressSnapshot(page) {
+    return page.evaluate(() => {
+        const status = document.getElementById('status');
+        const progressBar = document.getElementById('progressBar');
+        const progressText = document.getElementById('progressText');
+        const rawProgress = Number.parseFloat(progressBar?.style?.width || '');
+        const runtimeProgress = globalThis.__gwrVideoCliProgress;
+
+        return {
+            tone: status?.dataset?.tone || '',
+            status: status?.textContent || '',
+            progressText: progressText?.textContent || '',
+            progress: Number.isFinite(runtimeProgress?.progress)
+                ? Math.max(0, Math.min(1, runtimeProgress.progress))
+                : Number.isFinite(rawProgress)
+                    ? Math.max(0, Math.min(1, rawProgress / 100))
+                    : null,
+            phase: runtimeProgress?.phase || null,
+            processedFrames: Number.isFinite(runtimeProgress?.processedFrames)
+                ? runtimeProgress.processedFrames
+                : null,
+            frameEstimate: Number.isFinite(runtimeProgress?.frameEstimate)
+                ? runtimeProgress.frameEstimate
+                : null,
+            aiDenoiseFrames: Number.isFinite(runtimeProgress?.aiDenoiseFrames)
+                ? runtimeProgress.aiDenoiseFrames
+                : null,
+            aiReuseFrames: Number.isFinite(runtimeProgress?.aiReuseFrames)
+                ? runtimeProgress.aiReuseFrames
+                : null
+        };
+    });
+}
+
+function describeProgress(snapshot) {
+    return [snapshot?.progressText, snapshot?.status]
+        .map((value) => String(value || '').trim())
+        .filter(Boolean)
+        .filter((value, index, values) => values.indexOf(value) === index)
+        .join(' - ');
+}
 
 function configureVideoPageTimeouts(page) {
     page.setDefaultTimeout(DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS);
     page.setDefaultNavigationTimeout(DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS);
 }
 
+async function waitForVideoProcessing(page, options = {}) {
+    const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+        ? options.timeoutMs
+        : DEFAULT_VIDEO_TIMEOUT_MS;
+    const pollIntervalMs = Number.isFinite(options.pollIntervalMs) && options.pollIntervalMs >= 0
+        ? options.pollIntervalMs
+        : DEFAULT_VIDEO_PROGRESS_POLL_INTERVAL_MS;
+    const now = typeof options.now === 'function' ? options.now : Date.now;
+    const sleep = typeof options.sleep === 'function' ? options.sleep : delay;
+    const onProgress = typeof options.onProgress === 'function' ? options.onProgress : () => {};
+    const startedAt = now();
+    let lastActivityAt = startedAt;
+    let lastSnapshotKey = null;
+
+    while (true) {
+        const snapshot = await readVideoProgressSnapshot(page);
+        const elapsedMs = Math.max(0, now() - startedAt);
+        const result = { ...snapshot, elapsedMs };
+        const snapshotKey = JSON.stringify(snapshot);
+        if (snapshotKey !== lastSnapshotKey) {
+            lastActivityAt = now();
+            lastSnapshotKey = snapshotKey;
+            onProgress(result);
+        }
+
+        if (snapshot.tone === 'success' || snapshot.tone === 'error') {
+            return result;
+        }
+
+        const inactiveMs = Math.max(0, now() - lastActivityAt);
+        if (inactiveMs >= timeoutMs) {
+            const detail = describeProgress(snapshot);
+            const timeoutLabel = timeoutMs < 1000
+                ? `${Math.round(timeoutMs)} ms`
+                : `${Math.round(timeoutMs / 1000)} seconds`;
+            throw new Error(
+                `Video processing made no progress for ${timeoutLabel}${detail ? ` at ${detail}` : ''}. ` +
+                'Increase --video-timeout-ms for unusually long files.'
+            );
+        }
+
+        await sleep(Math.min(pollIntervalMs, Math.max(0, timeoutMs - inactiveMs)));
+    }
+}
+
 export {
     DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS,
+    DEFAULT_VIDEO_PROGRESS_POLL_INTERVAL_MS,
     DEFAULT_VIDEO_TIMEOUT_MS,
-    configureVideoPageTimeouts
+    configureVideoPageTimeouts,
+    describeProgress,
+    waitForVideoProcessing
 };

--- a/src/video-app.js
+++ b/src/video-app.js
@@ -625,8 +625,19 @@ async function runExport() {
             allenkFdncnnPadding,
             allenkFdncnnTemporalReuse,
             yieldToMainThread: yieldToBrowserFrame,
-            onProgress: ({ phase, progress, processedFrames, metadata, detection, aiDenoiseFrames, aiReuseFrames }) => {
+            onProgress: ({ phase, progress, processedFrames, frameEstimate, metadata, detection, aiDenoiseFrames, aiReuseFrames }) => {
                 if (jobId !== state.jobId) return;
+                const cliProgress = phase === 'detect'
+                    ? progress * 0.12
+                    : 0.12 + progress * 0.88;
+                window.__gwrVideoCliProgress = {
+                    phase,
+                    progress: cliProgress,
+                    processedFrames,
+                    frameEstimate,
+                    aiDenoiseFrames,
+                    aiReuseFrames
+                };
                 if (metadata) {
                     state.metadata = metadata;
                     renderMetadata(metadata);

--- a/tests/cli/gwrRemoveCommand.test.js
+++ b/tests/cli/gwrRemoveCommand.test.js
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+
+import { parseRemoveArgs, runRemoveCommand } from '../../src/cli/gwrRemoveCommand.js';
+
+test('video CLI help lists timeout and bitrate controls', async () => {
+  let stdout = '';
+  const code = await runRemoveCommand(['--help'], {
+    stdout: {
+      write(value) {
+        stdout += value;
+      }
+    },
+    stderr: { write() {} }
+  });
+
+  assert.equal(code, 0);
+  assert.match(stdout, /--video-timeout-ms <ms>/);
+  assert.match(stdout, /--video-bitrate-mbps <Mbps>/);
+});
+
+test('video bitrate option accepts a positive Mbps value', () => {
+  const options = parseRemoveArgs([
+    'input.mp4',
+    '--output',
+    'output.mp4',
+    '--video-bitrate-mbps',
+    '20'
+  ]);
+
+  assert.equal(options.ok, true);
+  assert.equal(options.videoBitrateMbps, 20);
+});
+
+test('video bitrate option rejects zero', () => {
+  const options = parseRemoveArgs([
+    'input.mp4',
+    '--output',
+    'output.mp4',
+    '--video-bitrate-mbps',
+    '0'
+  ]);
+
+  assert.equal(options.ok, false);
+  assert.match(options.error, /positive number/);
+});
+
+test('video CLI forwards timeout and bitrate to the video processor', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'gwr-video-cli-options-'));
+  const inputPath = path.join(tempDir, 'input.mp4');
+  const outputPath = path.join(tempDir, 'output.mp4');
+  const missingPagePath = path.join(tempDir, 'missing-preview.html');
+  await writeFile(inputPath, Buffer.from('video'));
+  let receivedOptions = null;
+  const io = {
+    stdout: { write() {} },
+    stderr: { write() {} }
+  };
+
+  const code = await runRemoveCommand([
+    inputPath,
+    '--output',
+    outputPath,
+    '--video-page',
+    missingPagePath,
+    '--video-timeout-ms',
+    '2500',
+    '--video-bitrate-mbps',
+    '20'
+  ], io, {
+    async removeVideoWatermarkFromFile(_inputPath, options) {
+      receivedOptions = options;
+      return { meta: { status: 'done' } };
+    }
+  });
+
+  assert.equal(code, 0);
+  assert.equal(receivedOptions.timeoutMs, 2500);
+  assert.equal(receivedOptions.videoBitrate, 20_000_000);
+});
+
+test('video CLI writes frame progress to stderr', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'gwr-video-cli-progress-'));
+  const inputPath = path.join(tempDir, 'input.mp4');
+  const outputPath = path.join(tempDir, 'output.mp4');
+  await writeFile(inputPath, Buffer.from('video'));
+  let stderr = '';
+  const io = {
+    stdout: { write() {} },
+    stderr: {
+      write(value) {
+        stderr += value;
+      }
+    }
+  };
+
+  const code = await runRemoveCommand([
+    inputPath,
+    '--output',
+    outputPath
+  ], io, {
+    async removeVideoWatermarkFromFile(_inputPath, options) {
+      options.onProgress({
+        phase: 'export',
+        progress: 0.5,
+        processedFrames: 5,
+        frameEstimate: 10,
+        aiDenoiseFrames: 3,
+        aiReuseFrames: 2
+      });
+      return { meta: { status: 'done' } };
+    }
+  });
+
+  assert.equal(code, 0);
+  assert.equal(stderr, '[video] 50% 5/10 frames (AI 3, reused 2)\n');
+});
+
+test('video CLI throttles progress updates within the same phase', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'gwr-video-cli-throttle-'));
+  const inputPath = path.join(tempDir, 'input.mp4');
+  const outputPath = path.join(tempDir, 'output.mp4');
+  await writeFile(inputPath, Buffer.from('video'));
+  let stderr = '';
+  const io = {
+    stdout: { write() {} },
+    stderr: {
+      write(value) {
+        stderr += value;
+      }
+    }
+  };
+
+  const code = await runRemoveCommand([inputPath, '--output', outputPath], io, {
+    async removeVideoWatermarkFromFile(_inputPath, options) {
+      options.onProgress({ phase: 'export', progress: 0.01, processedFrames: 1 });
+      options.onProgress({ phase: 'export', progress: 0.03, processedFrames: 3 });
+      options.onProgress({ phase: 'export', progress: 0.06, processedFrames: 6 });
+      return { meta: { status: 'done' } };
+    }
+  });
+
+  assert.equal(code, 0);
+  assert.equal(stderr, '[video] 1% 1 frames\n[video] 6% 6 frames\n');
+});

--- a/tests/scripts/gwrCli.test.js
+++ b/tests/scripts/gwrCli.test.js
@@ -71,6 +71,14 @@ function runCli(args, options = {}) {
   });
 }
 
+test('gwr help should list video timeout and bitrate controls', async () => {
+  const result = await runCli(['--help']);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /--video-timeout-ms <ms>/);
+  assert.match(result.stdout, /--video-bitrate-mbps <Mbps>/);
+});
+
 test('gwr remove should fail with exit code 2 when output target is missing', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'gwr-cli-missing-output-'));
   const inputPath = path.join(tempDir, 'input.synthetic');

--- a/tests/sdk/videoPreviewPage.test.js
+++ b/tests/sdk/videoPreviewPage.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 
 import {
+    removeVideoWatermarkFromFile,
     resolveDefaultVideoPreviewPage,
     withLocalVideoPreviewPage
 } from '../../src/sdk/video.js';
@@ -56,4 +57,56 @@ test('SDK video export should keep explicit bitrate through page auto presets', 
     const source = await readFile(new URL('../../src/sdk/video.js', import.meta.url), 'utf8');
 
     assert.match(source, /__gwrVideoOverrideBitrate/);
+});
+
+test('SDK video export forwards page progress to the caller', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'gwr-video-progress-page-'));
+    const pagePath = path.join(tempDir, 'video-preview.html');
+    const inputPath = path.join(tempDir, 'input.mp4');
+    await writeFile(inputPath, Buffer.from('video'));
+    await writeFile(pagePath, `<!doctype html>
+        <input id="fileInput" type="file">
+        <select id="denoiseBackend"><option value="allenk-fdncnn-browser-spike">default</option></select>
+        <input id="adaptiveAlpha" type="checkbox">
+        <input id="allowLowConfidence" type="checkbox">
+        <input id="alphaGain" type="number">
+        <input id="edgeDenoiseStrength" type="number">
+        <input id="residualCleanup" type="number">
+        <input id="videoBitrateMbps" type="number" value="12">
+        <button id="processBtn">Process</button>
+        <div id="status" data-tone="">Ready</div>
+        <div id="progressBar" style="width: 0%"></div>
+        <div id="progressText">Ready</div>
+        <a id="downloadBtn" aria-disabled="true">Download</a>
+        <script>
+            document.getElementById('processBtn').addEventListener('click', () => {
+                globalThis.__gwrVideoCliProgress = {
+                    phase: 'export',
+                    progress: 1,
+                    processedFrames: 1,
+                    frameEstimate: 1,
+                    aiDenoiseFrames: 0,
+                    aiReuseFrames: 0
+                };
+                document.getElementById('progressBar').style.width = '100%';
+                document.getElementById('progressText').textContent = 'Done';
+                const status = document.getElementById('status');
+                status.dataset.tone = 'success';
+                status.textContent = 'Done';
+                const link = document.getElementById('downloadBtn');
+                link.href = URL.createObjectURL(new Blob([new Uint8Array([1, 2, 3])], { type: 'video/mp4' }));
+                link.setAttribute('aria-disabled', 'false');
+            });
+        </script>`, 'utf8');
+    const progressEvents = [];
+
+    const result = await removeVideoWatermarkFromFile(inputPath, {
+        pagePath,
+        onProgress(progress) {
+            progressEvents.push(progress);
+        }
+    });
+
+    assert.deepEqual([...result.buffer], [1, 2, 3]);
+    assert.deepEqual(progressEvents.map((progress) => progress.processedFrames), [1]);
 });

--- a/tests/sdk/videoProgress.test.js
+++ b/tests/sdk/videoProgress.test.js
@@ -3,8 +3,35 @@ import assert from 'node:assert/strict';
 
 import {
     DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS,
-    configureVideoPageTimeouts
+    configureVideoPageTimeouts,
+    waitForVideoProcessing
 } from '../../src/sdk/videoProgress.js';
+
+function createSnapshotPage(...snapshots) {
+    let index = 0;
+    return {
+        async evaluate() {
+            const snapshot = snapshots[Math.min(index, snapshots.length - 1)];
+            index += 1;
+            return snapshot;
+        }
+    };
+}
+
+function processingSnapshot(overrides = {}) {
+    return {
+        tone: '',
+        status: 'Exporting',
+        progressText: 'Exporting frames',
+        progress: 0.1,
+        phase: 'export',
+        processedFrames: 1,
+        frameEstimate: 10,
+        aiDenoiseFrames: 0,
+        aiReuseFrames: 0,
+        ...overrides
+    };
+}
 
 test('page setup timeouts remain independent from export completion timeout', () => {
     const calls = [];
@@ -24,4 +51,48 @@ test('page setup timeouts remain independent from export completion timeout', ()
         ['action', DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS],
         ['navigation', DEFAULT_VIDEO_PAGE_SETUP_TIMEOUT_MS]
     ]);
+});
+
+test('video processing rejects after the configured inactivity period', async () => {
+    let clock = 0;
+    const page = createSnapshotPage(processingSnapshot());
+
+    await assert.rejects(
+        waitForVideoProcessing(page, {
+            timeoutMs: 100,
+            pollIntervalMs: 30,
+            now: () => clock,
+            sleep: async (ms) => {
+                clock += ms;
+            }
+        }),
+        /made no progress for 100 ms.*Exporting frames/s
+    );
+    assert.equal(clock, 100);
+});
+
+test('video processing may exceed the timeout while frame progress continues', async () => {
+    let clock = 0;
+    const progressEvents = [];
+    const page = createSnapshotPage(
+        processingSnapshot(),
+        processingSnapshot(),
+        processingSnapshot({ progress: 0.2, processedFrames: 2 }),
+        processingSnapshot({ progress: 0.2, processedFrames: 2 }),
+        processingSnapshot({ tone: 'success', status: 'Done', progress: 1, processedFrames: 10 })
+    );
+
+    const result = await waitForVideoProcessing(page, {
+        timeoutMs: 50,
+        pollIntervalMs: 20,
+        now: () => clock,
+        sleep: async (ms) => {
+            clock += ms;
+        },
+        onProgress: (progress) => progressEvents.push(progress)
+    });
+
+    assert.equal(result.tone, 'success');
+    assert.equal(result.elapsedMs, 80);
+    assert.deepEqual(progressEvents.map((event) => event.processedFrames), [1, 2, 10]);
 });


### PR DESCRIPTION
## Summary

- treat `--video-timeout-ms` as an inactivity timeout that resets when video progress changes
- report throttled phase, percentage, frame, and AI reuse progress through the SDK and CLI
- expose the existing video encoder bitrate control as `--video-bitrate-mbps`
- publish the progress callback contract in the TypeScript declarations and document the CLI behavior
- add unit, CLI, browser-level SDK, and TypeScript consumer coverage

## Why

After #135 separated Playwright setup timeouts from the export timeout, the completion wait still used one total wall-clock deadline. A valid long export could therefore fail even while frames were advancing. The CLI also had no way to reach the bitrate control already supported by the SDK and browser UI.

This keeps the scope focused on the remaining CLI/SDK portion of #110 and does not change watermark detection, restoration, encoding defaults, or muxing behavior.

Credit to @shantz1 for the original implementation and tests in #110.

## Validation

- `pnpm build`
- `pnpm test:serial`: 1698 tests, 1666 passed, 32 skipped, 0 failed
- focused CLI/SDK/type tests: 20 passed
- real repository MP4 with `--video-timeout-ms 60000 --video-bitrate-mbps 4`:
  - completed in 61.9 seconds while progress advanced from 8/240 to 240/240 frames
  - output: H.264/AAC, 720×1280, 24 fps, 240 frames, 10.005 seconds
- the same sample with a 100 ms inactivity timeout failed during watermark candidate matching with the expected no-progress error
