### PR TITLE
Skip residual cleanup over detailed backgrounds

### DIFF
--- a/src/video/videoCleanupBackends.js
+++ b/src/video/videoCleanupBackends.js
@@ -17,6 +17,17 @@ const DEFAULT_EDGE_DENOISE_STRENGTH = 0.65;
 const DEFAULT_ALLENK_FDNCNN_SIGMA = 25;
 const DEFAULT_ALLENK_FDNCNN_REUSE_THRESHOLD = 6.5;
 
+// Soft residual cleanup replaces footprint pixels with an inpainted and blurred
+// copy. Over a flat background that hides the rim left by alpha-map error and
+// costs nothing, because there is no detail to lose. Over a detailed background
+// it wipes texture the reverse alpha blend already recovered, and the resulting
+// smudge reads far worse than the residual it was meant to hide - while the
+// residual itself is masked by that same detail. So scale the cleanup down by
+// how much detail surrounds the footprint, measured as the RMS of the local
+// high-pass luma outside it.
+const CLEANUP_FLAT_TEXTURE_RMS = 12;   // at or below: flat, keep full cleanup
+const CLEANUP_BUSY_TEXTURE_RMS = 30;   // at or above: detailed, skip cleanup
+
 const VIDEO_CLEANUP_BACKENDS = Object.freeze({
     CANVAS_SOFT: 'canvas-soft',
     CANVAS_BILATERAL: 'canvas-bilateral'
@@ -598,6 +609,31 @@ export function buildEdgeCoreDenoiseWeightMap(alphaMap, width, height, strength)
     return gaussianBlurFloatMap(weights, width, height, 0.35, 1);
 }
 
+/**
+ * RMS of the high-pass luma outside the watermark footprint, i.e. how much real
+ * detail sits around it. Reuses the caller's blurred copy as the low-pass term.
+ */
+export function measureSurroundingTextureRms(padded, textureBase, weights) {
+    let sum = 0;
+    let count = 0;
+
+    for (let pixel = 0; pixel < weights.length; pixel++) {
+        if (weights[pixel] > 0.02) continue;
+
+        const idx = pixel * 4;
+        const detail = lumaAt(padded.data, idx) - lumaAt(textureBase, idx);
+        sum += detail * detail;
+        count++;
+    }
+
+    return count > 0 ? Math.sqrt(sum / count) : 0;
+}
+
+export function resolveContentTextureGate(textureRms) {
+    if (!Number.isFinite(textureRms)) return 1;
+    return 1 - smoothstep(CLEANUP_FLAT_TEXTURE_RMS, CLEANUP_BUSY_TEXTURE_RMS, textureRms);
+}
+
 function applySoftResidualCleanup(
     ctx,
     position,
@@ -620,6 +656,14 @@ function applySoftResidualCleanup(
     const paddedWeights = mapRoiWeightsToPaddedWeights(roiWeights, position, padded, padX, padY);
     const weights = gaussianBlurFloatMap(paddedWeights, padded.width, padded.height, 1);
     const textureBase = gaussianBlurPaddedImageData(padded, 2.2, 5);
+    const contentTextureGate = resolveContentTextureGate(
+        measureSurroundingTextureRms(padded, textureBase, weights)
+    );
+
+    // Detailed background: smoothing would cost more than the residual it hides.
+    // Bail out before the inpaint, which is the expensive part of this pass.
+    if (contentTextureGate <= 0.01) return;
+
     const structureGuard = protectStructure
         ? buildLumaStructureGuard(padded, highQuality ? 0.55 : 0.78)
         : null;
@@ -656,7 +700,7 @@ function applySoftResidualCleanup(
         const structureFactor = structureGuard
             ? Math.max(0.28, 1 - effectiveStructureGuard)
             : 1;
-        const blendWeight = baseBlendWeight * structureFactor;
+        const blendWeight = baseBlendWeight * structureFactor * contentTextureGate;
         if (blendWeight <= 0.01) continue;
 
         const idx = pixel * 4;
@@ -1399,6 +1443,8 @@ export async function applyVideoResidualCleanupAsync(ctx, position, alphaMap, op
 export {
     borrowCleanHighpassTexture,
     buildLumaStructureGuard,
+    CLEANUP_BUSY_TEXTURE_RMS,
+    CLEANUP_FLAT_TEXTURE_RMS,
     DEFAULT_DENOISE_BACKEND,
     DEFAULT_EDGE_DENOISE_STRENGTH,
     DEFAULT_HIGH_QUALITY_CLEANUP,

--- a/tests/video/videoCleanupBackends.test.js
+++ b/tests/video/videoCleanupBackends.test.js
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+    CLEANUP_BUSY_TEXTURE_RMS,
+    CLEANUP_FLAT_TEXTURE_RMS,
     DEFAULT_DENOISE_BACKEND,
     DEFAULT_EDGE_DENOISE_STRENGTH,
     DEFAULT_HIGH_QUALITY_CLEANUP,
@@ -18,7 +20,9 @@ import {
     buildGradientWeightMap,
     buildLumaStructureGuard,
     buildTextureRepairWeightMap,
-    normalizeVideoCleanupOptions
+    measureSurroundingTextureRms,
+    normalizeVideoCleanupOptions,
+    resolveContentTextureGate
 } from '../../src/video/videoCleanupBackends.js';
 import { resolveAllenkFdncnnRuntimeProfile } from '../../src/video/videoDenoiseRuntimePolicy.js';
 import { resolveVideoWatermarkCandidates } from '../../src/video/videoWatermarkCatalog.js';
@@ -1101,4 +1105,83 @@ test('applyVideoResidualCleanup should route canvas footprint polish backend', (
 
     assert.equal(result.denoiseBackend, VIDEO_DENOISE_BACKENDS.CANVAS_FOOTPRINT_POLISH);
     assert.equal(putCalls, 1);
+});
+
+function createSoftCleanupCtx(fillPixel) {
+    let putCalls = 0;
+    const ctx = {
+        canvas: { width: 200, height: 200 },
+        getImageData(x, y, width, height) {
+            const data = new Uint8ClampedArray(width * height * 4);
+            for (let row = 0; row < height; row++) {
+                for (let col = 0; col < width; col++) {
+                    const idx = (row * width + col) * 4;
+                    const value = fillPixel(x + col, y + row);
+                    data[idx] = value;
+                    data[idx + 1] = value;
+                    data[idx + 2] = value;
+                    data[idx + 3] = 255;
+                }
+            }
+            return { width, height, data };
+        },
+        putImageData() {
+            putCalls++;
+        }
+    };
+    return { ctx, putCalls: () => putCalls };
+}
+
+function runSoftCleanup(fillPixel) {
+    const { ctx, putCalls } = createSoftCleanupCtx(fillPixel);
+    applyVideoResidualCleanup(ctx, {
+        x: 60,
+        y: 60,
+        width: 48,
+        height: 48
+    }, createDiamondAlphaMap(48, 48), {
+        residualCleanupStrength: DEFAULT_RESIDUAL_CLEANUP_STRENGTH
+    });
+    return putCalls();
+}
+
+test('resolveContentTextureGate should keep cleanup on flat content and drop it on detailed content', () => {
+    assert.equal(resolveContentTextureGate(0), 1);
+    assert.equal(resolveContentTextureGate(CLEANUP_FLAT_TEXTURE_RMS), 1);
+    assert.equal(resolveContentTextureGate(CLEANUP_BUSY_TEXTURE_RMS), 0);
+    assert.equal(resolveContentTextureGate(CLEANUP_BUSY_TEXTURE_RMS * 2), 0);
+    assert.equal(resolveContentTextureGate(Number.NaN), 1);
+
+    const midpoint = resolveContentTextureGate(
+        (CLEANUP_FLAT_TEXTURE_RMS + CLEANUP_BUSY_TEXTURE_RMS) / 2
+    );
+    assert.ok(midpoint > 0 && midpoint < 1);
+});
+
+test('measureSurroundingTextureRms should ignore pixels inside the watermark footprint', () => {
+    const pixelCount = 16;
+    const padded = { width: 4, height: 4, data: new Uint8ClampedArray(pixelCount * 4) };
+    const textureBase = new Uint8ClampedArray(pixelCount * 4);
+    const weights = new Float32Array(pixelCount);
+
+    for (let pixel = 0; pixel < pixelCount; pixel++) {
+        const inFootprint = pixel < 4;
+        const value = inFootprint ? 200 : 10;
+        weights[pixel] = inFootprint ? 1 : 0;
+        for (let c = 0; c < 3; c++) {
+            padded.data[pixel * 4 + c] = value;
+        }
+    }
+
+    assert.ok(Math.abs(measureSurroundingTextureRms(padded, textureBase, weights) - 10) < 0.01);
+});
+
+test('soft residual cleanup should still run over a flat background', () => {
+    assert.equal(runSoftCleanup(() => 128), 1);
+});
+
+test('soft residual cleanup should be skipped over a detailed background', () => {
+    // Sharp stripes: smoothing here would wipe real texture that the reverse
+    // alpha blend already recovered, and the residual it hides is masked anyway.
+    assert.equal(runSoftCleanup((x, y) => (Math.floor(y / 2) % 2 === 0 ? 20 : 230)), 0);
 });


### PR DESCRIPTION
## Problem

When the watermark sits over detailed content, video removal leaves a footprint that is **more visible than the watermark it removed**.

`applySoftResidualCleanup` runs by default at strength 1.5 and replaces footprint pixels with an inpainted, blurred copy, with `textureGain` falling to 0.05 where the blend weight is high. Over a flat background there is no detail to lose, and the pass usefully hides the rim left by alpha-map error. Over a detailed background it discards texture that `removeWatermark` had already recovered correctly, leaving a flat smudge.

Measured on a 720p clip whose watermark sits over striped fabric, as the temporal contrast inside the footprint relative to the surrounding fabric (1.0 = fully restored):

| | contrast inside footprint |
| --- | --- |
| input, watermark present | 0.715 |
| current output | **0.549** |
| expected | ~1.0 |

The reverse alpha blend in `core/blendModes.js` is correct — the un-blend restores the texture, and this later pass then removes it again.

## Why not simply disable the pass

`--residual-cleanup-strength 0` fixes that clip but regresses flat ones, where the pass is doing real work. Residual score from `scripts/score-video-output-residual.js`:

| clip | cleanup on | cleanup off |
| --- | --- | --- |
| flat A | 0.0150 | 0.0516 |
| flat B | 0.0403 | 0.0745 |

The correct behaviour depends on the content, not on a fixed strength.

## Change

Scale the cleanup by how much detail surrounds the footprint, measured as the RMS of the high-pass luma outside it, and skip the pass once the surroundings are busy — which also skips the inpaint, the expensive part of this pass.

The thresholds come from measurement rather than taste: the two flat clips measure 6.0 and 9.7, the detailed one 36.7, so the ramp runs from 12 to 30.

## Verification

Three 720p clips, comparing builds before and after the change:

| clip | surrounding texture RMS | footprint delta | untouched control region |
| --- | --- | --- | --- |
| flat A | 6.0 | 0.35 | 0.70 |
| flat B | 9.7 | 2.32 | 1.49 |
| detailed | 36.7 | **11.87** | 1.90 |

On the flat clips the footprint changes *less* between the two builds than an untouched control region does, i.e. the difference is encoder noise and the output is effectively unchanged. Only the detailed clip moves.

Contrast inside the footprint on the detailed clip: **0.549 → 0.983**.

Residual score before → after: flat A 0.0150 → 0.0133, flat B 0.0403 → 0.0309, detailed 0.0231 → 0.0653. The rise on the detailed clip is an artifact of that metric: it is a template correlation, so the flattened, over-smoothed output it used to produce scored well while looking wrong. The contrast figure and the frames below are the better guide here.

## Tests

Four cases added to `tests/video/videoCleanupBackends.test.js`: gate boundaries, footprint exclusion in the RMS measure, cleanup still running over a flat background, and cleanup skipped over a detailed one.

`node --test` over `tests/video` and `tests/core`: 577 pass, 0 fail.

## Frames

Crop around the watermark footprint, two frames, 3x nearest-neighbour. Left: input. Middle: current output. Right: with this change.

<img width="1032" height="710" alt="pr_comparison" src="https://github.com/user-attachments/assets/e03e097a-1196-499b-9a5d-a8869d451420" />