### PR TITLE
Fix animated Gemini video watermark tracks

### DIFF
--- a/src/video/videoExport.js
+++ b/src/video/videoExport.js
@@ -14,7 +14,8 @@ import {
 import { removeWatermark } from '../core/blendModes.js';
 import {
     detectVideoWatermarkFromFramesAsync,
-    scoreVideoWatermarkFrame
+    scoreVideoWatermarkFrame,
+    selectVideoWatermarkDetectionForFrame
 } from './videoWatermarkDetector.js';
 import { resolveVideoWatermarkCandidates } from './videoWatermarkCatalog.js';
 import {
@@ -841,6 +842,42 @@ async function processWatermarkRoiAsync(ctx, detection, options) {
     };
 }
 
+export async function processVideoWatermarkFrame(ctx, detection, trackStates = new Map(), options = {}) {
+    const selection = selectVideoWatermarkDetectionForFrame(ctx, detection);
+    const selectedDetection = selection?.detection || detection;
+    const trackId = selectedDetection?.candidate?.id || [
+        selectedDetection?.position?.x,
+        selectedDetection?.position?.y,
+        selectedDetection?.position?.width,
+        selectedDetection?.position?.height
+    ].join(':');
+    const trackState = trackStates.get(trackId) || {};
+    const frameResult = await processWatermarkRoiAsync(ctx, selectedDetection, {
+        ...options,
+        seedAlphaGain: selectedDetection?.alphaSeed?.seedGain ?? options.seedAlphaGain ?? DEFAULT_ALPHA_GAIN,
+        previousAlphaGain: trackState.previousAlphaGain ?? null,
+        previousTemporalRoi: trackState.previousTemporalRoi ?? null,
+        previousTemporalDeltaFrame: trackState.previousTemporalDeltaFrame ?? null,
+        previousTemporalMatchDeltaFrame: trackState.previousTemporalMatchDeltaFrame ?? null,
+        allenkFdncnnFrameCache: trackState.allenkFdncnnFrameCache ?? options.allenkFdncnnFrameCache ?? {}
+    });
+
+    trackState.previousAlphaGain = frameResult.alphaGain;
+    trackState.previousTemporalRoi = frameResult.skipped ? null : frameResult.temporalRoi || null;
+    trackState.previousTemporalDeltaFrame = frameResult.skipped ? null : frameResult.temporalDeltaFrame || null;
+    trackState.previousTemporalMatchDeltaFrame = frameResult.skipped
+        ? null
+        : frameResult.temporalMatchDeltaFrame || null;
+    trackState.allenkFdncnnFrameCache = trackState.allenkFdncnnFrameCache ?? options.allenkFdncnnFrameCache ?? {};
+    trackStates.set(trackId, trackState);
+
+    return {
+        ...frameResult,
+        selectedDetection,
+        selection
+    };
+}
+
 export async function removeGeminiVideoWatermark(file, options = {}) {
     const requestedAlphaGain = Number.isFinite(options.alphaGain) && options.alphaGain > 0
         ? options.alphaGain
@@ -933,13 +970,7 @@ export async function removeGeminiVideoWatermark(file, options = {}) {
     let aiDenoiseFrames = 0;
     let aiReuseFrames = 0;
     let lastTimestamp = -Infinity;
-    let previousAlphaGain = null;
-    let previousTemporalRoi = null;
-    let previousTemporalDeltaFrame = null;
-    let previousTemporalMatchDeltaFrame = null;
-    const allenkFdncnnFrameCache = denoiseBackend === VIDEO_DENOISE_BACKENDS.ALLENK_FDNCNN_BROWSER_SPIKE
-        ? {}
-        : null;
+    const trackStates = new Map();
     const fallbackDuration = metadata.frameRate > 0 ? 1 / metadata.frameRate : 1 / 30;
 
     try {
@@ -958,9 +989,8 @@ export async function removeGeminiVideoWatermark(file, options = {}) {
 
             try {
                 sample.draw(ctx, 0, 0, metadata.width, metadata.height);
-                const frameResult = await processWatermarkRoiAsync(ctx, detection, {
+                const frameResult = await processVideoWatermarkFrame(ctx, detection, trackStates, {
                     seedAlphaGain: alphaGain,
-                    previousAlphaGain,
                     adaptiveAlpha,
                     residualCleanupStrength,
                     highQualityCleanup,
@@ -972,14 +1002,9 @@ export async function removeGeminiVideoWatermark(file, options = {}) {
                     allenkFdncnnSigma: options.allenkFdncnnSigma,
                     allenkFdncnnPadding,
                     allenkFdncnnTemporalReuse: options.allenkFdncnnTemporalReuse,
-                    allenkFdncnnFrameCache,
-                    previousTemporalRoi,
-                    previousTemporalDeltaFrame,
-                    previousTemporalMatchDeltaFrame,
                     highConfidenceThreshold: options.highConfidenceThreshold ?? FRAME_HIGH_CONFIDENCE,
                     lowConfidenceThreshold: options.lowConfidenceThreshold ?? FRAME_LOW_CONFIDENCE
                 });
-                previousAlphaGain = frameResult.alphaGain;
                 const denoiseStatus = frameResult.cleanupResult?.denoiseRuntimeStatus;
                 if (denoiseStatus === 'applied') {
                     aiDenoiseFrames++;
@@ -988,19 +1013,10 @@ export async function removeGeminiVideoWatermark(file, options = {}) {
                 }
                 if (frameResult.skipped) {
                     skippedFrames++;
-                    previousTemporalRoi = null;
-                    previousTemporalDeltaFrame = null;
-                    previousTemporalMatchDeltaFrame = null;
                 } else if (frameResult.mode === 'adaptive') {
                     adaptiveFrames++;
-                    previousTemporalRoi = frameResult.temporalRoi || null;
-                    previousTemporalDeltaFrame = frameResult.temporalDeltaFrame || null;
-                    previousTemporalMatchDeltaFrame = frameResult.temporalMatchDeltaFrame || null;
                 } else {
                     seedFrames++;
-                    previousTemporalRoi = frameResult.temporalRoi || null;
-                    previousTemporalDeltaFrame = frameResult.temporalDeltaFrame || null;
-                    previousTemporalMatchDeltaFrame = frameResult.temporalMatchDeltaFrame || null;
                 }
             } finally {
                 sample.close();

--- a/src/video/videoWatermarkCatalog.js
+++ b/src/video/videoWatermarkCatalog.js
@@ -217,6 +217,14 @@ function getExplicitCandidates(width, height) {
                 sourcePriority: 0
             },
             {
+                id: 'veo-720x1280-animated-compact-24',
+                label: '720x1280 animated compact, 24px, margin 48',
+                size: 24,
+                marginRight: 48,
+                marginBottom: 48,
+                sourcePriority: 0
+            },
+            {
                 id: 'veo-720x1280-vertical-inset',
                 label: '720x1280 vertical inset, 35px, margin 102/96',
                 size: 35,

--- a/src/video/videoWatermarkDetector.js
+++ b/src/video/videoWatermarkDetector.js
@@ -1076,6 +1076,79 @@ function summarizeCandidate(scores) {
     };
 }
 
+export function selectIndependentVideoWatermarkTracks(summaries, {
+    minConfidence = DEFAULT_MIN_CONFIDENCE
+} = {}) {
+    if (!Array.isArray(summaries) || summaries.length === 0) return [];
+
+    const qualified = summaries.filter((summary, index) => {
+        if (index === 0) return true;
+        return summary.meanConfidence >= minConfidence;
+    });
+    const selected = [];
+
+    for (const summary of qualified) {
+        const candidate = summary.candidate;
+        const candidateSize = Number(candidate?.size);
+        const candidateArea = candidateSize * candidateSize;
+        const overlapsSelected = selected.some((selectedSummary) => {
+            const selectedCandidate = selectedSummary.candidate;
+            const selectedSize = Number(selectedCandidate?.size);
+            const overlapWidth = Math.max(0, Math.min(
+                Number(candidate?.x) + candidateSize,
+                Number(selectedCandidate?.x) + selectedSize
+            ) - Math.max(Number(candidate?.x), Number(selectedCandidate?.x)));
+            const overlapHeight = Math.max(0, Math.min(
+                Number(candidate?.y) + candidateSize,
+                Number(selectedCandidate?.y) + selectedSize
+            ) - Math.max(Number(candidate?.y), Number(selectedCandidate?.y)));
+            const smallerArea = Math.min(candidateArea, selectedSize * selectedSize);
+            return smallerArea > 0 && (overlapWidth * overlapHeight) / smallerArea >= 0.5;
+        });
+        if (!overlapsSelected) selected.push(summary);
+    }
+
+    return selected;
+}
+
+export function selectVideoWatermarkDetectionForFrame(imageSource, detection) {
+    const detections = Array.isArray(detection?.detections) && detection.detections.length > 0
+        ? detection.detections
+        : [detection];
+    let selected = null;
+
+    for (const candidateDetection of detections) {
+        if (!candidateDetection?.position || !candidateDetection?.alphaMap) continue;
+        const position = candidateDetection.position;
+        const hasRoiReader = typeof imageSource?.getImageData === 'function';
+        const imageData = hasRoiReader
+            ? imageSource.getImageData(position.x, position.y, position.width, position.height)
+            : imageSource;
+        const frameScore = scoreVideoWatermarkFrame(
+            imageData,
+            hasRoiReader
+                ? { x: 0, y: 0, width: position.width, height: position.height }
+                : position,
+            candidateDetection.alphaMap
+        );
+        const meanConfidence = Math.max(0.01, Number(candidateDetection.meanConfidence) || 0.01);
+        const normalizedConfidence = frameScore.confidence / meanConfidence;
+        if (
+            !selected ||
+            normalizedConfidence > selected.normalizedConfidence ||
+            (normalizedConfidence === selected.normalizedConfidence && frameScore.confidence > selected.frameScore.confidence)
+        ) {
+            selected = {
+                detection: candidateDetection,
+                frameScore,
+                normalizedConfidence
+            };
+        }
+    }
+
+    return selected;
+}
+
 export function detectDiamondVideoWatermarkFromFrames({
     frames,
     width,
@@ -1133,10 +1206,14 @@ export function detectDiamondVideoWatermarkFromFrames({
         });
 
     const best = summaries[0];
+    const trackSummaries = selectIndependentVideoWatermarkTracks(summaries, { minConfidence });
     const voteRatio = frames.length > 0 ? best.votes / frames.length : 0;
+    const combinedVoteRatio = frames.length > 0
+        ? Math.min(1, trackSummaries.reduce((sum, summary) => sum + summary.votes, 0) / frames.length)
+        : 0;
     const isConfident =
         best.meanConfidence >= minConfidence &&
-        voteRatio >= 0.6;
+        (voteRatio >= 0.6 || (trackSummaries.length > 1 && combinedVoteRatio >= 0.6));
     const position = {
         x: best.candidate.x,
         y: best.candidate.y,
@@ -1153,6 +1230,40 @@ export function detectDiamondVideoWatermarkFromFrames({
         alphaMapOptions
     });
     const { alphaMap, alphaSeed } = alphaSelection;
+    const detections = [{
+        watermarkKind: 'diamond',
+        position,
+        alphaMap,
+        alphaSeed,
+        candidate: best.candidate,
+        meanConfidence: best.meanConfidence
+    }];
+
+    for (const summary of trackSummaries.slice(1)) {
+        const candidatePosition = {
+            x: summary.candidate.x,
+            y: summary.candidate.y,
+            width: summary.candidate.size,
+            height: summary.candidate.size
+        };
+        const candidateAlphaSelection = selectVideoAlphaShapeForDetection({
+            frames,
+            position: candidatePosition,
+            candidate: summary.candidate,
+            best: summary,
+            voteRatio: frames.length > 0 ? summary.votes / frames.length : 0,
+            frameWinners,
+            alphaMapOptions
+        });
+        detections.push({
+            watermarkKind: 'diamond',
+            position: candidatePosition,
+            alphaMap: candidateAlphaSelection.alphaMap,
+            alphaSeed: candidateAlphaSelection.alphaSeed,
+            candidate: summary.candidate,
+            meanConfidence: summary.meanConfidence
+        });
+    }
 
     return {
         watermarkKind: 'diamond',
@@ -1160,6 +1271,7 @@ export function detectDiamondVideoWatermarkFromFrames({
         alphaMap,
         alphaSeed,
         candidate: best.candidate,
+        detections,
         isConfident,
         summary: {
             frameCount: frames.length,
@@ -1257,10 +1369,14 @@ export async function detectDiamondVideoWatermarkFromFramesAsync({
         });
 
     const best = summaries[0];
+    const trackSummaries = selectIndependentVideoWatermarkTracks(summaries, { minConfidence });
     const voteRatio = frames.length > 0 ? best.votes / frames.length : 0;
+    const combinedVoteRatio = frames.length > 0
+        ? Math.min(1, trackSummaries.reduce((sum, summary) => sum + summary.votes, 0) / frames.length)
+        : 0;
     const isConfident =
         best.meanConfidence >= minConfidence &&
-        voteRatio >= 0.6;
+        (voteRatio >= 0.6 || (trackSummaries.length > 1 && combinedVoteRatio >= 0.6));
     const position = {
         x: best.candidate.x,
         y: best.candidate.y,
@@ -1277,6 +1393,40 @@ export async function detectDiamondVideoWatermarkFromFramesAsync({
         alphaMapOptions
     });
     const { alphaMap, alphaSeed } = alphaSelection;
+    const detections = [{
+        watermarkKind: 'diamond',
+        position,
+        alphaMap,
+        alphaSeed,
+        candidate: best.candidate,
+        meanConfidence: best.meanConfidence
+    }];
+
+    for (const summary of trackSummaries.slice(1)) {
+        const candidatePosition = {
+            x: summary.candidate.x,
+            y: summary.candidate.y,
+            width: summary.candidate.size,
+            height: summary.candidate.size
+        };
+        const candidateAlphaSelection = selectVideoAlphaShapeForDetection({
+            frames,
+            position: candidatePosition,
+            candidate: summary.candidate,
+            best: summary,
+            voteRatio: frames.length > 0 ? summary.votes / frames.length : 0,
+            frameWinners,
+            alphaMapOptions
+        });
+        detections.push({
+            watermarkKind: 'diamond',
+            position: candidatePosition,
+            alphaMap: candidateAlphaSelection.alphaMap,
+            alphaSeed: candidateAlphaSelection.alphaSeed,
+            candidate: summary.candidate,
+            meanConfidence: summary.meanConfidence
+        });
+    }
 
     return {
         watermarkKind: 'diamond',
@@ -1284,6 +1434,7 @@ export async function detectDiamondVideoWatermarkFromFramesAsync({
         alphaMap,
         alphaSeed,
         candidate: best.candidate,
+        detections,
         isConfident,
         summary: {
             frameCount: frames.length,

--- a/tests/video/videoExportCleanupOptions.test.js
+++ b/tests/video/videoExportCleanupOptions.test.js
@@ -6,6 +6,56 @@ import {
     resolveExportAllenkFdncnnPadding,
     VIDEO_DENOISE_BACKENDS
 } from '../../src/video/videoExport.js';
+import * as videoExportModule from '../../src/video/videoExport.js';
+import { getVideoAlphaMap } from '../../src/video/videoWatermarkDetector.js';
+
+function createImageContext(width, height, value = 90) {
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let pixel = 0; pixel < width * height; pixel++) {
+        const idx = pixel * 4;
+        data[idx] = value;
+        data[idx + 1] = value;
+        data[idx + 2] = value;
+        data[idx + 3] = 255;
+    }
+
+    return {
+        canvas: { width, height },
+        data,
+        getImageData(x, y, roiWidth, roiHeight) {
+            const roi = new Uint8ClampedArray(roiWidth * roiHeight * 4);
+            for (let row = 0; row < roiHeight; row++) {
+                for (let col = 0; col < roiWidth; col++) {
+                    const sourceIdx = (((y + row) * width) + x + col) * 4;
+                    const targetIdx = ((row * roiWidth) + col) * 4;
+                    roi.set(data.subarray(sourceIdx, sourceIdx + 4), targetIdx);
+                }
+            }
+            return { width: roiWidth, height: roiHeight, data: roi };
+        },
+        putImageData(imageData, x, y) {
+            for (let row = 0; row < imageData.height; row++) {
+                for (let col = 0; col < imageData.width; col++) {
+                    const sourceIdx = ((row * imageData.width) + col) * 4;
+                    const targetIdx = (((y + row) * width) + x + col) * 4;
+                    data.set(imageData.data.subarray(sourceIdx, sourceIdx + 4), targetIdx);
+                }
+            }
+        }
+    };
+}
+
+function applyWhiteWatermark(ctx, alphaMap, position) {
+    for (let row = 0; row < position.height; row++) {
+        for (let col = 0; col < position.width; col++) {
+            const alpha = alphaMap[row * position.width + col];
+            const idx = (((position.y + row) * ctx.canvas.width) + position.x + col) * 4;
+            for (let channel = 0; channel < 3; channel++) {
+                ctx.data[idx + channel] = Math.round(alpha * 255 + (1 - alpha) * ctx.data[idx + channel]);
+            }
+        }
+    }
+}
 
 test('resolveExportAllenkFdncnnPadding should keep explicit Allenk padding', () => {
     const padding = resolveExportAllenkFdncnnPadding({
@@ -89,4 +139,47 @@ test('createVideoExportEncodingConfig should force BT.709 limited-range decoder 
         matrix: 'bt709',
         fullRange: false
     });
+});
+
+test('processVideoWatermarkFrame should process only the active watermark track', async () => {
+    const ctx = createImageContext(96, 64);
+    const relocated = {
+        candidate: { id: 'relocated-16' },
+        position: { x: 4, y: 4, width: 16, height: 16 },
+        alphaMap: getVideoAlphaMap(16),
+        alphaSeed: { seedGain: 1 },
+        meanConfidence: 0.4
+    };
+    const standard = {
+        candidate: { id: 'standard-12' },
+        position: { x: 76, y: 48, width: 12, height: 12 },
+        alphaMap: getVideoAlphaMap(12),
+        alphaSeed: { seedGain: 1 },
+        meanConfidence: 0.15
+    };
+    applyWhiteWatermark(ctx, standard.alphaMap, standard.position);
+    const relocatedBefore = ctx.getImageData(4, 4, 16, 16).data;
+
+    const result = await videoExportModule.processVideoWatermarkFrame?.(
+        ctx,
+        { ...relocated, detections: [relocated, standard] },
+        new Map(),
+        {
+            adaptiveAlpha: false,
+            residualCleanupStrength: 0,
+            highQualityCleanup: false,
+            denoiseBackend: VIDEO_DENOISE_BACKENDS.NONE,
+            edgeDenoiseStrength: 0,
+            textureRepair: false,
+            textureRepairStrength: 0,
+            highConfidenceThreshold: 0.14,
+            lowConfidenceThreshold: 0.035
+        }
+    );
+
+    assert.equal(result?.selectedDetection.candidate.id, 'standard-12');
+    assert.deepEqual(ctx.getImageData(4, 4, 16, 16).data, relocatedBefore);
+    assert.ok(ctx.getImageData(76, 48, 12, 12).data.some((value, index) => (
+        index % 4 !== 3 && value < 100
+    )));
 });

--- a/tests/video/videoWatermarkCatalog.test.js
+++ b/tests/video/videoWatermarkCatalog.test.js
@@ -116,6 +116,17 @@ test('resolveVideoWatermarkCandidates should expose confirmed 720x1280 vertical 
                 exactSizeVariant: true
             },
             {
+                id: 'veo-720x1280-animated-compact-24',
+                x: 648,
+                y: 1208,
+                size: 24,
+                marginRight: 48,
+                marginBottom: 48,
+                sourceFamily: 'exact-size-exception',
+                evidenceGate: 'required',
+                exactSizeVariant: true
+            },
+            {
                 id: 'veo-720x1280-portrait-48',
                 x: 600,
                 y: 1160,

--- a/tests/video/videoWatermarkDetector.test.js
+++ b/tests/video/videoWatermarkDetector.test.js
@@ -16,6 +16,7 @@ import {
     scoreVideoWatermarkFramePolarity,
     summarizeVideoWatermarkFrameEvidence
 } from '../../src/video/videoWatermarkDetector.js';
+import * as videoWatermarkDetectorModule from '../../src/video/videoWatermarkDetector.js';
 import { resolveVideoWatermarkCandidates } from '../../src/video/videoWatermarkCatalog.js';
 
 function createPatternImageData(width, height) {
@@ -300,6 +301,176 @@ test('detectVideoWatermarkFromFrames should vote for the candidate present acros
     assert.equal(result.candidate.id, target.id);
     assert.equal(result.position.x, target.x);
     assert.equal(result.position.y, target.y);
+    assert.equal(result.isConfident, true);
+});
+
+test('detectVideoWatermarkFromFrames should preserve independent alternating watermark tracks', () => {
+    const width = 192;
+    const height = 128;
+    const relocated = {
+        id: 'alternating-relocated-32',
+        label: 'alternating relocated 32',
+        x: 12,
+        y: 12,
+        size: 32,
+        width: 32,
+        height: 32,
+        sourceFamily: 'exact-size-exception',
+        evidenceGate: 'required'
+    };
+    const standard = {
+        id: 'alternating-standard-18',
+        label: 'alternating standard 18',
+        x: 158,
+        y: 98,
+        size: 18,
+        width: 18,
+        height: 18,
+        sourceFamily: 'reference-projected',
+        evidenceGate: 'standard'
+    };
+    const relocatedAlpha = getVideoAlphaMap(relocated.size, { candidate: relocated });
+    const standardAlpha = getVideoAlphaMap(standard.size, { candidate: standard });
+    const frames = [];
+
+    for (let i = 0; i < 6; i++) {
+        const imageData = createPatternImageData(width, height);
+        const active = i < 3 ? relocated : standard;
+        applyWhiteWatermark(
+            imageData,
+            active === relocated ? relocatedAlpha : standardAlpha,
+            { x: active.x, y: active.y, width: active.size, height: active.size }
+        );
+        frames.push({ timestamp: i / 24, imageData });
+    }
+
+    const result = detectVideoWatermarkFromFrames({
+        frames,
+        width,
+        height,
+        candidates: [relocated, standard],
+        minConfidence: 0.02
+    });
+
+    assert.deepEqual(
+        result.detections?.map((detection) => detection.candidate.id).sort(),
+        [relocated.id, standard.id].sort()
+    );
+    assert.equal(result.isConfident, true);
+});
+
+test('selectIndependentVideoWatermarkTracks should collapse overlapping catalog variants', () => {
+    const summaries = [
+        {
+            candidate: { id: 'relocated-48', x: 576, y: 1136, size: 48, evidenceGate: 'required' },
+            meanConfidence: 0.3909,
+            maxConfidence: 0.9658
+        },
+        {
+            candidate: { id: 'overlapping-inset-35', x: 583, y: 1149, size: 35, evidenceGate: 'required' },
+            meanConfidence: 0.2198,
+            maxConfidence: 0.4003
+        },
+        {
+            candidate: { id: 'animated-compact-24', x: 648, y: 1208, size: 24, evidenceGate: 'required' },
+            meanConfidence: 0.5341,
+            maxConfidence: 0.9889
+        }
+    ];
+
+    const selected = videoWatermarkDetectorModule.selectIndependentVideoWatermarkTracks?.(summaries, {
+        minConfidence: 0.18
+    });
+
+    assert.deepEqual(selected?.map((summary) => summary.candidate.id), ['relocated-48', 'animated-compact-24']);
+});
+
+test('selectVideoWatermarkDetectionForFrame should choose the active fallback track', () => {
+    const width = 192;
+    const height = 128;
+    const relocated = {
+        candidate: { id: 'relocated-32' },
+        position: { x: 12, y: 12, width: 32, height: 32 },
+        alphaMap: getVideoAlphaMap(32),
+        meanConfidence: 0.4
+    };
+    const standard = {
+        candidate: { id: 'standard-18' },
+        position: { x: 158, y: 98, width: 18, height: 18 },
+        alphaMap: getVideoAlphaMap(18),
+        meanConfidence: 0.15
+    };
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let pixel = 0; pixel < width * height; pixel++) {
+        const idx = pixel * 4;
+        data[idx] = 90;
+        data[idx + 1] = 90;
+        data[idx + 2] = 90;
+        data[idx + 3] = 255;
+    }
+    const imageData = { width, height, data };
+    applyWhiteWatermark(imageData, standard.alphaMap, standard.position);
+
+    const selected = videoWatermarkDetectorModule.selectVideoWatermarkDetectionForFrame?.(
+        imageData,
+        { ...relocated, detections: [relocated, standard] }
+    );
+
+    assert.equal(selected?.detection.candidate.id, 'standard-18');
+});
+
+test('detectVideoWatermarkFromFramesAsync should preserve independent alternating watermark tracks', async () => {
+    const width = 192;
+    const height = 128;
+    const relocated = {
+        id: 'async-alternating-relocated-32',
+        label: 'async alternating relocated 32',
+        x: 12,
+        y: 12,
+        size: 32,
+        width: 32,
+        height: 32,
+        sourceFamily: 'exact-size-exception',
+        evidenceGate: 'required'
+    };
+    const standard = {
+        id: 'async-alternating-standard-18',
+        label: 'async alternating standard 18',
+        x: 158,
+        y: 98,
+        size: 18,
+        width: 18,
+        height: 18,
+        sourceFamily: 'reference-projected',
+        evidenceGate: 'standard'
+    };
+    const relocatedAlpha = getVideoAlphaMap(relocated.size, { candidate: relocated });
+    const standardAlpha = getVideoAlphaMap(standard.size, { candidate: standard });
+    const frames = [];
+
+    for (let i = 0; i < 6; i++) {
+        const imageData = createPatternImageData(width, height);
+        const active = i < 3 ? relocated : standard;
+        applyWhiteWatermark(
+            imageData,
+            active === relocated ? relocatedAlpha : standardAlpha,
+            { x: active.x, y: active.y, width: active.size, height: active.size }
+        );
+        frames.push({ timestamp: i / 24, imageData });
+    }
+
+    const result = await detectVideoWatermarkFromFramesAsync({
+        frames,
+        width,
+        height,
+        candidates: [relocated, standard],
+        minConfidence: 0.02
+    });
+
+    assert.deepEqual(
+        result.detections?.map((detection) => detection.candidate.id).sort(),
+        [relocated.id, standard.id].sort()
+    );
     assert.equal(result.isConfident, true);
 });
 


### PR DESCRIPTION
Fixes #136

## What changed
- add the confirmed 720x1280 animated compact geometry (24px, 48px margins)
- preserve non-overlapping watermark tracks and select the active track per frame
- keep alpha, temporal, and AI cache state isolated per track

## Validation
- pnpm test: 1671 passed, 32 skipped, 0 failed
- real issue sample: 240/240 frames exported and 469 AAC packets preserved
- relocated 48px confidence: 0.3909 -> 0.0685-0.0729
- compact 24px confidence: 0.5344 -> 0.0780-0.0889 across two default encodes; visual crop review is clean, and the variation comes from absent-track frames after H.264 re-encoding
- no package version change