### PR TITLE
Fix issue #101 2K watermark anchor

### DIFF
--- a/src/core/geminiSizeCatalog.js
+++ b/src/core/geminiSizeCatalog.js
@@ -25,6 +25,10 @@ const GEMINI_3X_CURRENT_1K_LARGE_MARGIN_WATERMARK_CONFIG = Object.freeze({
     marginRight: 96,
     marginBottom: 96
 });
+const GEMINI_3X_CURRENT_2K_LARGE_MARGIN_SIZE_KEYS = new Set([
+    '2048x2048',
+    '2400x1792'
+]);
 const GEMINI_3X_V2_SMALL_WATERMARK_CONFIG = Object.freeze({
     logoSize: 36,
     marginRight: 96,
@@ -377,6 +381,31 @@ export function resolveOfficialGeminiSearchConfigEntries(
                     resolutionTier: match.resolutionTier,
                     aspectRatio: match.aspectRatio,
                     source: 'allenk-v2-small'
+                }));
+            }
+        }
+        if (
+            match?.modelFamily === 'gemini-3.x-image' &&
+            match.resolutionTier === '2k' &&
+            GEMINI_3X_CURRENT_2K_LARGE_MARGIN_SIZE_KEYS.has(
+                `${normalizedWidth}x${normalizedHeight}`
+            )
+        ) {
+            const currentLargeMarginVariant = createCurrentLargeMarginVariantConfig(
+                exactOfficialConfig,
+                normalizedWidth,
+                normalizedHeight,
+                { allowAnyBase: true }
+            );
+            if (currentLargeMarginVariant) {
+                entries.push(createCatalogEntry(currentLargeMarginVariant, {
+                    family: 'known-current-variant',
+                    sourcePriority: 1,
+                    evidenceGate: 'required',
+                    modelFamily: match.modelFamily,
+                    resolutionTier: match.resolutionTier,
+                    aspectRatio: match.aspectRatio,
+                    source: '202608-2k-large-margin'
                 }));
             }
         }

--- a/tests/core/geminiSizeCatalog.test.js
+++ b/tests/core/geminiSizeCatalog.test.js
@@ -196,6 +196,54 @@ test('resolveOfficialGeminiSearchConfigs should prefer current 48px exact offici
     ]);
 });
 
+test('resolveOfficialGeminiSearchConfigEntries should add the evidence-gated 48px R96 candidate to exact Gemini 3.x 2K outputs', () => {
+    for (const [width, height] of [
+        [2048, 2048],
+        [2400, 1792]
+    ]) {
+        const entries = resolveOfficialGeminiSearchConfigEntries(width, height);
+        const entry = entries.find((candidate) => (
+            candidate.config.logoSize === 48 &&
+            candidate.config.marginRight === 96 &&
+            candidate.config.marginBottom === 96 &&
+            candidate.config.alphaVariant == null
+        ));
+
+        assert.deepEqual(entry, {
+            config: { logoSize: 48, marginRight: 96, marginBottom: 96 },
+            metadata: {
+                family: 'known-current-variant',
+                sourcePriority: 1,
+                evidenceGate: 'required',
+                modelFamily: 'gemini-3.x-image',
+                resolutionTier: '2k',
+                aspectRatio: width === height ? '1:1' : '4:3',
+                source: '202608-2k-large-margin'
+            }
+        });
+    }
+});
+
+test('resolveOfficialGeminiSearchConfigEntries should not generalize the 48px R96 candidate to exact Gemini 3.x 4K outputs', () => {
+    const entries = resolveOfficialGeminiSearchConfigEntries(4096, 4096);
+
+    assert.equal(entries.some((entry) => (
+        entry.config.logoSize === 48 &&
+        entry.config.marginRight === 96 &&
+        entry.config.marginBottom === 96
+    )), false);
+});
+
+test('resolveOfficialGeminiSearchConfigEntries should not generalize the 48px R96 candidate to unconfirmed exact Gemini 3.x 2K outputs', () => {
+    const entries = resolveOfficialGeminiSearchConfigEntries(2752, 1536);
+
+    assert.equal(entries.some((entry) => (
+        entry.config.logoSize === 48 &&
+        entry.config.marginRight === 96 &&
+        entry.config.marginBottom === 96
+    )), false);
+});
+
 test('resolveOfficialGeminiSearchConfigEntries should expose explicit catalog family and priority metadata', () => {
     const entries = resolveOfficialGeminiSearchConfigEntries(768, 1376);
 

--- a/tests/core/pipelineInitialSelection.test.js
+++ b/tests/core/pipelineInitialSelection.test.js
@@ -1438,6 +1438,27 @@ test('collectInitialWatermarkCandidates should derive the exact source witness i
     }
 });
 
+test('collectInitialWatermarkCandidates should rescue the exact 48px R96 source witness on exact Gemini 3.x 2K dimensions', () => {
+    const alpha48 = getEmbeddedAlphaMap(48);
+    const imageData = createFlatImageData(2048, 2048, 72);
+    const trial = createExact48R96Trial(imageData, alpha48);
+    applyWhiteWatermark(imageData, alpha48, trial.position);
+
+    const input = createExact48R96CollectionInput(imageData, alpha48, null);
+    input.config = { logoSize: 96, marginRight: 64, marginBottom: 64 };
+    input.catalogPriorConfig = input.config;
+    const result = collectInitialWatermarkCandidates(input);
+
+    assert.equal(result.bestEffortFallback, true);
+    assert.equal(result.bestEffortReason, 'exact-48-r96-source-witness');
+    assert.equal(result.hypotheses.length, 1);
+    assert.deepEqual(result.hypotheses[0].trial.config, {
+        logoSize: 48,
+        marginRight: 96,
+        marginBottom: 96
+    });
+});
+
 test('collectInitialWatermarkCandidates should reject an alpha mismatch or a geometry absent from the current catalog', () => {
     const alpha48 = getEmbeddedAlphaMap(48);
     const imageData = createFlatImageData(320, 320, 72);
@@ -1454,7 +1475,7 @@ test('collectInitialWatermarkCandidates should reject an alpha mismatch or a geo
     assert.equal(alphaMismatch.bestEffortFallback, false);
     assert.equal(alphaMismatch.hypotheses.length, 0);
 
-    const catalogAbsentImage = createFlatImageData(2048, 2048, 72);
+    const catalogAbsentImage = createFlatImageData(4096, 4096, 72);
     const catalogAbsentTrial = createExact48R96Trial(
         catalogAbsentImage,
         alpha48


### PR DESCRIPTION
## What changed

- add an evidence-gated `48x48` watermark candidate at `96px` right/bottom margins for the two exact Gemini 3.x 2K sizes confirmed by the latest issue #101 samples: `2048x2048` and `2400x1792`
- reuse the existing exact-48 R96 source-witness path instead of changing global thresholds, alpha templates, or cleanup behavior
- keep unconfirmed 2K sizes and all 4K sizes unchanged
- add catalog and pipeline regressions, including the existing `2752x1536` canonical 96px sample as a negative boundary

## Why

The 12 newly reported samples all contain a real `48x48` watermark at approximately `96/96` margins, but the exact 2K catalog only proposed `96x96` candidates. That caused five skips and frequent selection of weak large candidates at the wrong location.

A first broad 2K hypothesis exposed a regression on the known `2752x1536` canonical 96px fixture, so the final change is deliberately limited to the two dimensions independently confirmed by the reporter set.

## User impact

- all 12 newly reported samples are now processed at the correct `48/96/96` anchor
- diagnostic benchmark improves from 5/12 passes and 7/12 applied to 11/12 passes and 12/12 applied
- the remaining sample is processed with a minor residual; it is not skipped and does not show the previous wrong-location damage
- no version bump or release artifacts are included

## Validation

- TDD regressions were observed failing before the catalog change
- Issue #101 reporter benchmark: 11 passed, 1 residual-edge, 0 skipped; all 12 selected `48/96/96`
- visual bottom-right crop review: previous large brown/black wrong-location holes are gone
- complete suite: 1,677 passed, 32 skipped, 0 failed
- production build: passed
- `git diff --check`: passed

Closes no issue yet; keep #101 open until a published build is available and the reporter can retest.
