### PR TITLE
Preserve unanimous video watermark tracks for issue 150

### DIFF
--- a/src/video/videoWatermarkDetector.js
+++ b/src/video/videoWatermarkDetector.js
@@ -1083,7 +1083,11 @@ export function selectIndependentVideoWatermarkTracks(summaries, {
 
     const qualified = summaries.filter((summary, index) => {
         if (index === 0) return true;
-        return summary.meanConfidence >= minConfidence;
+        // When every sample agrees on the primary, a zero-vote background track
+        // must not displace it through per-frame confidence normalization.
+        const primary = summaries[0];
+        const unanimousPrimary = primary.frames > 0 && primary.votes === primary.frames;
+        return summary.meanConfidence >= minConfidence && (!unanimousPrimary || summary.votes > 0);
     });
     const selected = [];
 

--- a/tests/video/videoWatermarkDetector.test.js
+++ b/tests/video/videoWatermarkDetector.test.js
@@ -364,17 +364,20 @@ test('selectIndependentVideoWatermarkTracks should collapse overlapping catalog 
         {
             candidate: { id: 'relocated-48', x: 576, y: 1136, size: 48, evidenceGate: 'required' },
             meanConfidence: 0.3909,
-            maxConfidence: 0.9658
+            maxConfidence: 0.9658,
+            votes: 5
         },
         {
             candidate: { id: 'overlapping-inset-35', x: 583, y: 1149, size: 35, evidenceGate: 'required' },
             meanConfidence: 0.2198,
-            maxConfidence: 0.4003
+            maxConfidence: 0.4003,
+            votes: 0
         },
         {
             candidate: { id: 'animated-compact-24', x: 648, y: 1208, size: 24, evidenceGate: 'required' },
             meanConfidence: 0.5341,
-            maxConfidence: 0.9889
+            maxConfidence: 0.9889,
+            votes: 7
         }
     ];
 
@@ -383,6 +386,41 @@ test('selectIndependentVideoWatermarkTracks should collapse overlapping catalog 
     });
 
     assert.deepEqual(selected?.map((summary) => summary.candidate.id), ['relocated-48', 'animated-compact-24']);
+});
+
+test('independent tracks should reject the zero-vote background candidate from issue 150', () => {
+    const summaries = [
+        {
+            candidate: { id: 'relocated-48', x: 576, y: 1136, size: 48 },
+            meanConfidence: 0.9404598428782002,
+            frames: 12,
+            votes: 12
+        },
+        {
+            candidate: { id: 'animated-compact-24', x: 648, y: 1208, size: 24 },
+            meanConfidence: 0.18923886692970018,
+            frames: 12,
+            votes: 0
+        }
+    ];
+    assert.deepEqual(
+        videoWatermarkDetectorModule.selectIndependentVideoWatermarkTracks(summaries),
+        [summaries[0]]
+    );
+    // Preserve the primary best-effort result when sampling is inconclusive.
+    const uncertain = { ...summaries[0], meanConfidence: 0.01, votes: 0 };
+    assert.deepEqual(
+        videoWatermarkDetectorModule.selectIndependentVideoWatermarkTracks([uncertain]),
+        [uncertain]
+    );
+    // Issue 136's already-processed clip has inconsistent sampling. Keep its
+    // established alternating path; forcing one track creates fresh dark dots.
+    const mixedPrimary = { ...summaries[0], meanConfidence: 0.56466, votes: 8 };
+    const fallback = { ...summaries[1], meanConfidence: 0.2141 };
+    assert.deepEqual(
+        videoWatermarkDetectorModule.selectIndependentVideoWatermarkTracks([mixedPrimary, fallback]),
+        [mixedPrimary, fallback]
+    );
 });
 
 test('selectVideoWatermarkDetectionForFrame should choose the active fallback track', () => {


### PR DESCRIPTION
When every detection sample selects the primary 48px watermark, a zero-vote 24px background candidate can still replace it during per-frame export. On the #150 original, the browser baseline reproduced this on 105 of 192 frames, leaving the main watermark and creating an unwanted dark dot.

Exclude zero-vote secondary tracks only when the primary wins every sample. Keep the primary best-effort fallback and existing mixed-track behavior, including the #136 controls.

Validated integration head: `6a3a3f8b089960bc7a997bddc461cc88806b3501`, incorporating main `25ef59dfa8322303ba98643adc486bc152587dc6` without conflicts. The diff against main remains limited to the detector and its focused regression tests.

Validation:
- [Current integrated CI](https://github.com/GargantuaX/gemini-watermark-remover/actions/runs/35634362543): build, project surface checks and SDK smoke passed; full suite 1711 passed, 0 failed, 33 skipped.
- Default headless Chromium 145, without custom security/experimental launch flags: three complete core exports retained 192/240/240 decoded frames and first/last video timestamps.
- Actual video-preview page upload/process flow on #150 succeeded with its automatic Canvas preset and with the Node wrapper's default ONNX backend configuration. The latter used the normal WASM fallback when WebGPU was unavailable. Both produced usable 192-frame download blobs. This exercises page behavior; it does not claim a direct invocation of the exported Node wrapper or a native download-click test.
- Independent packet checks matched all nonnegative-time audio payload hashes, PTS/DTS and durations to the original inputs for all five integrated outputs. #150 and #136a omit the original negative-time AAC priming packet with Skip Samples=1024; no listening-quality claim is made.
- Reviewed #150 frame50/100 comparisons show substantial improvement. Existing dark smearing in the #136 processed control remains an independent quality issue; this PR is not a universal cleanup-quality fix.

Refs #150. Ready for merge consideration after scoped review; not merged, released or deployed. The separately deployed website still requires its own version update and release validation. #165 and #152 remain outside this change.
