### PR TITLE
feat(video): add 4K (3840x2160) watermark candidate support

### DIFF
--- a/src/video/videoWatermarkCatalog.js
+++ b/src/video/videoWatermarkCatalog.js
@@ -251,5 +251,25 @@ function getExplicitCandidates(width, height) {
         }), width, height)).filter(isCandidateInBounds);
     }
 
+    if (width === 3840 && height === 2160) {
+        return [
+            {
+                id: 'veo-3840x2160-davinci-160',
+                label: '3840x2160 160px, margin 198/265',
+                size: 160,
+                marginRight: 198,
+                marginBottom: 265,
+                sourcePriority: 0
+            }
+        ].map((candidate) => withVideoBounds(buildCandidate(candidate, width, height, 1, {
+            referenceSize: false,
+            scaledFromReference: false,
+            sourceCandidateId: null,
+            sourceFamily: 'exact-size-exception',
+            evidenceGate: 'standard',
+            exactSizeVariant: true
+        }), width, height)).filter(isCandidateInBounds);
+    }
+
     return [];
 }

--- a/tests/video/videoDenoiseRuntimePolicy.test.js
+++ b/tests/video/videoDenoiseRuntimePolicy.test.js
@@ -97,7 +97,8 @@ test('resolveAllenkFdncnnRuntimeProfile should cover every video catalog positio
             height: 2160,
             expected: {
                 'veo-1080p-standard': { profileId: 'allenk-fdncnn-200', size: 144, padding: 28 },
-                'veo-1080p-inset': { profileId: 'allenk-fdncnn-200', size: 144, padding: 28 }
+                'veo-1080p-inset': { profileId: 'allenk-fdncnn-200', size: 144, padding: 28 },
+                'veo-3840x2160-davinci-160': { profileId: 'allenk-fdncnn-200', size: 160, padding: 20 }
             }
         },
         {


### PR DESCRIPTION
### Summary
This PR adds support for 4K (3840x2160) video watermark detection and removal.

### Changes
- Added 3840x2160 candidate profile (160px size, margin 198/265) to `getExplicitCandidates` in `src/video/videoWatermarkCatalog.js`.
- Updated test expectations in `tests/video/videoDenoiseRuntimePolicy.test.js` to verify the 4K candidate fits the 200px Allenk FDnCNN model contract with appropriate padding.
- All 93 video tests pass (`node --test tests/video/*.test.js`).